### PR TITLE
Add: ユーザー詳細画面の実装

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,3 +3,4 @@
 //= link_tree ../javascripts .js 
 //= link sidebar-toggle.js
 //= link avatar-prev.js
+//= link user-show.js

--- a/app/assets/javascripts/user-show.js
+++ b/app/assets/javascripts/user-show.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const MobileSizes = document.querySelectorAll('.mobile-size');
+  const PCSizes = document.querySelectorAll('.pc-size');
+
+  // 初期表示の設定
+  updateDisplay();
+
+  // 画面サイズが変更された時にサイドバーの表示を切り替える
+  window.addEventListener('resize', updateDisplay);
+
+  function updateDisplay() {
+    const isMobile = window.innerWidth <= 767;
+
+    MobileSizes.forEach(function(MobileSize) {
+      MobileSize.classList.toggle('d-none', !isMobile);
+    });
+
+    PCSizes.forEach(function(PCSize) {
+      PCSize.classList.toggle('d-none', isMobile);
+    });
+  }
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,10 +29,6 @@ body {
   padding: 0 5px;
 }
 
-.underline {
-  border-bottom: 5px solid #77e1f7
-}
-
 .operetion-bg {
   background-color: rgba(0, 0, 0, 0.7);
   border-radius: 50%;
@@ -46,4 +42,76 @@ body {
 
 .hover-opacity-50:hover {
   opacity: 0.5;
+}
+
+.over-line {
+  &.border-1 {
+    border-top: 1px solid;
+  }
+  &.border-2 {
+    border-top: 2px solid;
+  }
+  &.border-3 {
+    border-top: 3px solid;
+  }
+  &.border-4 {
+    border-top: 4px solid;
+  }
+  &.border-5 {
+    border-top: 5px solid;
+  }
+}
+
+.under-line {
+  &.border-1 {
+    border-bottom: 1px solid;
+  }
+  &.border-2 {
+    border-bottom: 2px solid;
+  }
+  &.border-3 {
+    border-bottom: 3px solid;
+  }
+  &.border-4 {
+    border-bottom: 4px solid;
+  }
+  &.border-5 {
+    border-bottom: 5px solid;
+  }
+}
+
+.left-line {
+  &.border-1 {
+    border-left: 1px solid;
+  }
+  &.border-2 {
+    border-left: 2px solid;
+  }
+  &.border-3 {
+    border-left: 3px solid;
+  }
+  &.border-4 {
+    border-left: 4px solid;
+  }
+  &.border-5 {
+    border-left: 5px solid;
+  }
+}
+
+.right-line {
+  &.border-1 {
+    border-right: 1px solid;
+  }
+  &.border-2 {
+    border-right: 2px solid;
+  }
+  &.border-3 {
+    border-right: 3px solid;
+  }
+  &.border-4 {
+    border-right: 4px solid;
+  }
+  &.border-5 {
+    border-right: 5px solid;
+  }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def index
-    @users = User.with_attached_avatar.order(created_at: :desc).page(params[:page]).per(15)
+    @users = User.with_attached_avatar.where.not(id: current_user.id).order(created_at: :desc).page(params[:page]).per(15)
   end
 
   def new
@@ -21,7 +21,10 @@ class UsersController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @user = User.find(params[:id])
+    @posts = @user.posts.order(created_at: :desc).page(params[:page]).per(10)
+  end
 
   private
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,12 +2,12 @@
   <div class="card-header">
     <div class="d-flex align-items-center ps-0">
       <div class="user-avatar mx-2">
-        <%= link_to posts_path do %>
+        <%= link_to user_path(current_user) do %>
           <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
         <% end %>
       </div>
       <div class="name_field text-break">
-        <%= current_user.name %>
+        <%= link_to current_user.name, user_path(current_user), class: "fw-bold text-secondary hover-opacity-50", style:"text-decoration:none;" %>
       </div>
     </div>
   </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -4,16 +4,16 @@
       <div class="container">
         <div class="user-panel d-flex align-items-center py-3">
           <div class="user-avatar me-2">
-            <%= link_to posts_path do %>
+            <%= link_to user_path(post.user) do %>
               <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
             <% end %>
           </div>
           <div class="user-name d-flex align-items-center text-break">
-            <%= link_to post.user.name, posts_path, class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
+            <%= link_to post.user.name, user_path(post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
           </div>
           <div class="operation_area d-flex align-items-center ml-auto">
             <% if current_user.own?(post) %>
-              <%= render 'crud_menus', post: post %>
+              <%= render 'posts/crud_menus', post: post %>
             <% end %>
           </div>
         </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid p-0">
-  <div class="title-area title-underline my-2">
+  <div class="title-area under-line border-4 my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
   

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container p-2">
-  <div class="title-area underline my-2">
+  <div class="title-area under-line border-4 my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 
@@ -8,7 +8,7 @@
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
-      <p><%= t(".no_post") %></p>
+      <p class="text-secondary><%= t(".no_post") %></p>
       <%= link_to 'ログの第一号になろう！', new_post_path %>
     <% end %>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid p-0">
-  <div class="title-area title-underline my-2">
+  <div class="title-area under-line border-4 my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -35,12 +35,12 @@
     <div class="card-header">
       <div class="d-flex align-items-center">
         <div class="user-avatar me-2 sm-mx-2">
-          <%= link_to posts_path do %>
+          <%= link_to user_path(@post.user) do %>
             <%= image_tag @post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
           <% end %>
         </div>
         <div class="user-name d-flex align-items-center text-break">
-          <%= link_to @post.user.name, posts_path, class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
+          <%= link_to @post.user.name, user_path(@post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
         </div>
         <span class="text-secondary mx-2">
           <i class="far fa-clock clock-icon me-1">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,16 +1,16 @@
 <nav class="navbar navbar-expand-lg navbar-light px-4">
   <div class="container-fluid px-0">
     <%= link_to root_path, class: "navbar-brand" do %>
-      <%= image_tag 'chari-log-logo.png', style: "height: 45px;" %>
+      <%= image_tag 'chari-log-logo.png', class: "ms-2", style: "height: 45px;" %>
     <% end %>
     <div class="user-panel d-lg-flex d-none align-items-center">
       <div class="user-avatar mx-2">
-        <%= link_to posts_path do %>
+        <%= link_to user_path(current_user) do %>
           <%= image_tag current_user.avatar.variant(gravity: :center, resize: "40x40^!", crop:"40x40+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
         <% end %>
       </div>
       <div class="user-name">
-        <%= link_to current_user.name, posts_path, class: "d-block font-weight-bold text-secondary" %>
+        <%= link_to current_user.name, user_path(current_user), class: "d-block font-weight-bold text-secondary" %>
       </div>
       <div class="new-post-btn ms-4">
         <%= link_to t("defaults.post"), new_post_path, class: "btn btn-sm btn-info fw-bold px-3 py-2" %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -3,13 +3,13 @@
     <ul>
       <div class="user-panel d-lg-none d-flex align-items-center border-bottom border-dark pb-3">
         <div class="user-avatar mx-2">
-        <%= link_to posts_path do %>
-          <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
-        <% end %>
-      </div>
+          <%= link_to user_path(current_user) do %>
+            <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+          <% end %>
+        </div>
         <div class="d-flex flex-column">
           <div class="user-name">
-            <%= link_to current_user.name.truncate(12), posts_path, class: "d-block font-weight-bold text-secondary" %>
+            <%= link_to current_user.name.truncate(12), user_path(current_user), class: "d-block font-weight-bold text-secondary" %>
           </div>
           <div class="new-post-btn">
             <%= link_to t("defaults.post"), new_post_path, class: "btn btn-sm btn-info fw-bold p-0 px-2" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,27 +5,27 @@
         <thead>
           <tr>
             <th></th>
-            <th><%= User.model_name.human %></th>
-            <th>Mybike</th>
+            <th class="text-nowrap"><%= User.human_attribute_name(:name) %></th>
+            <th><%= User.human_attribute_name(:my_bike) %></th>
             <th></th>
           </tr>
         </thead>
         <tbody>
           <% @users.each do |user| %>
             <tr>
-              <th class="text-center">
-                <%= link_to posts_path do %>
+              <th class="align-middle">
+                <%= link_to user_path(user) do %>
                   <%= image_tag user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
                 <% end %>
               </th>
               <th class="align-middle">
-                <%= link_to user.name, posts_path, class: "text-center fw-bold text-dark hover-opacity-50", style: "text-decoration:none;" %>
+                <%= link_to user.name, user_path(user), class: "text-nowrap text-dark hover-opacity-50", style: "text-decoration:none;" %>
               </th>
               <th class="align-middle">
                 <div class="text-nowrap"><%= user.my_bike_i18n %></div>
               </th>
               <th class="align-middle">
-                <%= link_to t("defaults.follow"), "#", class: "btn btn-primary" %>
+                <%= link_to t("defaults.follow"), "#", class: "btn btn-primary fw-bold" %>
               </th>
             </tr>
           <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -38,7 +38,7 @@
             </div>
             <div class="form-group">
               <i class="fas fa-bicycle"></i>
-              <%= f.label :my_bike, class: "fw-bold text-break" %>
+              <%= f.label t(".my_bike"), class: "fw-bold text-break" %>
               <%= f.select :my_bike, User.my_bikes.keys, {}, class: 'form-control bg-light' %>
             </div>
             <div class="form-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,126 @@
-<h1>Users#show</h1>
-<p>Find me in app/views/users/show.html.erb</p>
+<%= javascript_include_tag "user-show.js" %>
+
+<div class="container px-lg-5 px-md-4">
+  <div class="row pb-4 mb-5 border-bottom">
+    <div class="user-panel d-flex flex-column flex-md-row justify-content-center align-items-center">
+      <div class="user-avatar d-flex align-items-center mt-3 mb-4">
+        <%= image_tag @user.avatar.variant(gravity: :center, resize: "90x90^!", crop:"90x90+0+0"), class: "rounded-circle bg-dark-subtle me-4", style: "display: inline-block;" %>
+        <div class="follow-btn mobile-size" style="display: inline-block;">
+          <% if @user.id == current_user.id %>
+            <div class="item-info mb-2">
+              <button class="btn btn-danger dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <%= t(".item_management") %>
+              </button>
+              <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
+                <%= link_to users_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                    <i class="fas fa-book"></i>  <%= t("defaults.to_items_page") %>
+                <% end %>
+                <%= link_to posts_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                    <i class="fas fa-search-plus"></i>  <%= t("defaults.to_new_item_page") %>
+                <% end %>
+              </div>
+            </div>
+            <div class="edit-profile">
+              <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  <%= t(".setting_profile") %>
+                </button>
+                <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
+                  <%= link_to users_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                      <i class="fas fa-id-card"></i>  <%= t("defaults.to_edit_profile_page") %>
+                  <% end %>
+                  <%= link_to posts_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                      <i class="fas fa-lock"></i>  <%= t("defaults.to_reset_page") %>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          <% else %>
+            <%= link_to t("defaults.follow"), "#", class: "btn btn-primary fw-bold p-3" %>
+          <% end %>
+        </div>
+      </div>
+      <div class="d-flex flex-column fw-bold me-3">
+        <div class="user-element left-line border-4 border-primary ps-3 mb-3 mb-md-0">
+          <div class="user-name mb-2">
+            <i class="fas fa-user me-1"></i>
+            <%= User.human_attribute_name(:name) %>
+            <span>：</span>
+            <%= @user.name %>
+          </div>
+          <div class="bike-name mb-2">
+            <i class="fas fa-bicycle me-1"></i>
+            <%= User.human_attribute_name(:my_bike) %>
+            <span>：</span>
+            <%= @user.my_bike_i18n %>
+          </div>
+          <div class="element-count d-flex flex-wrap">
+            <div class="me-3">フォロワー10件</div>
+            <div class="me-3">フォロー中10件</div>
+            <div>投稿<%= @user.posts.count %>件</div>
+          </div>
+        </div>
+        <div class="bio-area mobile-size fw-bold">
+          <% if @user.bio.present? %>
+            <div class="text"><%= @user.bio %></div>
+          <% else %>
+            <div class="text-secondary"><%= t(".no_bio") %></div>
+          <% end %>
+        </div>
+      </div>
+      <div class="follow-btn pc-size mx-auto">
+        <% if @user.id == current_user.id %>
+          <div class="item-info mb-2">
+            <button class="btn btn-danger dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <%= t(".item_management") %>
+            </button>
+            <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
+              <%= link_to users_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                  <i class="fas fa-book"></i>  <%= t("defaults.to_items_page") %>
+              <% end %>
+              <%= link_to posts_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                  <i class="fas fa-search-plus"></i>  <%= t("defaults.to_new_item_page") %>
+              <% end %>
+            </div>
+          </div>
+          <div class="edit-profile">
+            <div class="dropdown">
+              <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <%= t(".setting_profile") %>
+              </button>
+              <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
+                <%= link_to users_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                    <i class="fas fa-id-card"></i>  <%= t("defaults.to_edit_profile_page") %>
+                <% end %>
+                <%= link_to posts_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                    <i class="fas fa-lock"></i>  <%= t("defaults.to_reset_page") %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% else %>
+          <%= link_to t("defaults.follow"), "#", class: "btn btn-primary fw-bold p-3" %>
+        <% end %>
+      </div>
+    </div>
+    <div class="bio-area pc-size fw-bold">
+      <% if @user.bio.present? %>
+        <div><%= @user.bio %></div>
+      <% else %>
+        <div class="text-secondary"><%= t(".no_bio") %></div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="row mb-4">
+    <% if @posts.present? %>
+      <%= render @posts %>
+    <% else %>
+      <p class="text-secondary><%= t(".no_post") %></p>
+      <%= link_to 'あなたのログを残そう', new_post_path %>
+    <% end %>
+  </div>
+
+  <%= paginate @posts, theme: 'twitter-bootstrap-4' %>
+
+</div>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -87,9 +87,9 @@ ja:
         images: '投稿画像'
       user:
         avatar: 'アイコン'
-        bio: 'ひと言'
+        bio: '自己紹介'
         email: 'メールアドレス'
-        my_bike: 'お気に入り(所有する)自転車メーカー'
+        my_bike: 'Mybike'
         name: 'ユーザー名'
         password: 'パスワード'
         password_confirmation: 'パスワード確認'

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -21,6 +21,10 @@ ja:
     to_register_page: '新規登録ページへ'
     to_login_page: 'ログインページへ'
     to_posts_page: '投稿一覧へ'
+    to_items_page: 'アイテム一覧へ'
+    to_new_item_page: 'アイテム登録へ'
+    to_edit_profile_page: 'プロフィール設定'
+    to_reset_page: 'メール・パスワード設定'
     look_password: 'パスワードを表示'
     message:
       require_login: 'ログインしてください'
@@ -42,12 +46,17 @@ ja:
       no_user: '他にユーザーはいません。あなたが最初の利用者です！'
     new:
       title: 'ユーザー登録'
+      my_bike: 'お気に入り(所有する)自転車メーカー'
       registered: '登録済みの方はこちら'
     create:
       success: 'ユーザー登録が完了しました'
       fail: 'ユーザー登録に失敗しました'
     show:
       title: 'ユーザー詳細'
+      setting_profile: '登録情報設定'
+      item_management: 'アイテム管理'
+      no_post: 'まだ投稿がありません'
+      no_bio: '自己紹介は登録されていません'
   user_sessions:
     new:
       title: 'ログイン'


### PR DESCRIPTION
## 概要

* 投稿詳細画面の実装
* レスポンシブ対応のためのjsコード実装
* showアクション周りのコード編集
* ユーザー名・アバター画像から詳細画面へ遷移できるようパスを設定


## 確認方法

1. ログイン後、それぞれのユーザー名からユーザー詳細ページに遷移できることを確認して下さい。
2. ログインユーザー自身の詳細ページでは"アイテム管理"と"登録情報設定"の二つのドロップダウンが表示されていることを、他ユーザーの詳細ページでは"フォローする"のボタンが表示されていることを確認して下さい。
3. 開発者ツールのページから多様な画面サイズに対応しているか否かを確認して下さい。


## 以下のissueに関するpull requestです

#11 
