### PR TITLE
Add: プロフィール編集画面の実装

### DIFF
--- a/app/assets/javascripts/avatar-prev.js.erb
+++ b/app/assets/javascripts/avatar-prev.js.erb
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const AvatarInput = document.querySelector('#user_avatar');
   const AvatarInputArea = document.querySelector('.input-area');
   const sampleImagePath = '<%= asset_path('sample.png') %>';
+  const avatarUrl = document.querySelector('#prev_img').dataset.avatarUrl;
   
   // 初期表示の設定
   if (window.innerWidth >= 450) {
@@ -59,7 +60,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     DeleteBtnArea.addEventListener('click', function() {
       // プレビューを削除
-      PrevImg.src = sampleImagePath;
+      PrevImg.src = avatarUrl || sampleImagePath;
       // ×ボタンを非表示
       DeleteBtnArea.classList.remove('open');
       // アップロードファイルをクリア

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -13,7 +13,7 @@
 }
 
 .avatar-input-downsize {
-  padding: 20px 30px;
+  padding: 20px 27px;
 }
 
 .position-relative {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -44,9 +44,15 @@ class PostsController < ApplicationController
 
   # DELETE /posts/1 or /posts/1.json
   def destroy
+    user = @post.user
     @post.images.purge
     @post.destroy!
-    redirect_to posts_path, success: t("defaults.message.deleted", item: Post.model_name.human)
+
+    if came_from_user_show?
+      redirect_to user_path(user), success: t("defaults.message.deleted", item: Post.model_name.human)
+    else
+      redirect_to posts_path, success: t("defaults.message.deleted", item: Post.model_name.human)
+    end
   end
 
   # 画像アップロード用のアクション
@@ -79,5 +85,10 @@ class PostsController < ApplicationController
       filename: file.original_filename,
       content_type: file.content_type
     )
+  end
+
+  def came_from_user_show?
+    referer = request.referer
+    referer.present? && referer.include?('users')
   end
 end

--- a/app/controllers/profile/attachments_controller.rb
+++ b/app/controllers/profile/attachments_controller.rb
@@ -1,0 +1,17 @@
+class Profile::AttachmentsController < ApplicationController
+  def destroy
+    avatar = ActiveStorage::Attachment.find(params[:id])
+  
+    # Get user associated with the avatar
+    user = avatar.record
+
+    # Purge the current avatar
+    avatar.purge
+
+    # Attach 'sample.png' as a new avatar
+    sample_avatar_path = Rails.root.join('app', 'assets', 'images', 'sample.png')
+    user.avatar.attach(io: File.open(sample_avatar_path), filename: 'sample.png')
+
+    redirect_to edit_profile_path
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,24 @@
+class ProfilesController < ApplicationController
+  before_action :set_profile, only: %i[edit update]
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to user_path(@user), success: t('defaults.message.updated', item: t('defaults.profile'))
+    else
+      flash.now[:danger] = t('defaults.message.not_updated', item: t('defaults.profile'))
+      render :edit
+    end
+  end
+
+  private
+
+  def set_profile
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :my_bike, :bio, :avatar, :avatar_cache)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
     <meta charset="utf-8">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.9.0/css/all.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
   </head>
 
   <body>
@@ -61,5 +62,7 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>
   </body>
 </html>

--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -6,7 +6,7 @@
       <% end %>
     </li>
     <li class="list-inline-item me-1">
-      <%= link_to post_path(post), class: "hover-opacity-50", method: :delete, data: {confirm: "ログを削除しますか"} do %>
+      <%= link_to post_path(post), class: "hover-opacity-50", method: :delete, data: {confirm: t('defaults.message.delete_confirm', item: Post.model_name.human)} do %>
         <i class="fas fa-trash fa-lg text-dark"></i>
       <% end %>
     </li>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -41,7 +41,7 @@
         <div class="form-group">
           <%= f.label :images, class: "input-area text-center d-block w-100 border-dashed border-2 rounded-1 border-success pointer py-2 py-lg-4", for: "file-upload" do %>
             <span class="text-center text-success">
-              <i class="fas fa-camera me-2"></i>画像を選択する
+              <i class="fas fa-camera me-2"></i><%= t("defaults.select_images") %>
             </span>
             <%= f.file_field :images, id: "file-upload", multiple: true, accept: '.jpeg, .jpg, .png', style: "display: none;", data: { images_target: "select", action: "change->images#selectImages" } %>
           <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,12 +4,14 @@
   </div>
 
   <!-- 掲示板一覧 -->
-  <div class="row mb-4">
+  <div class="row mb-5">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
-      <p class="text-secondary><%= t(".no_post") %></p>
-      <%= link_to 'ログの第一号になろう！', new_post_path %>
+      <div class="text-center text-secondary my-5"><%= t(".no_post") %></div>
+      <div class="text-center">
+        <%= link_to t(".log_first!"), new_post_path, class: "btn btn-info" %>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -56,10 +56,12 @@
         <div class="swiper-wrapper">
           <% @post.images.each do |image| %>
             <div class="swiper-slide">
-              <%# スマホの画像サイズ %>
-              <%= image_tag(image.variant(resize_to_fit: [450,300], gravity: 'Center', strip: true), class: "d-block mx-auto img-fluid d-sm-none") %>
-              <%# PCの画像サイズ %>
-              <%= image_tag(image.variant(resize_to_fit: [500,415], gravity: 'Center', strip: true), class: "d-none mx-auto img-fluid d-sm-block") %>
+              <%= link_to image, "data-lightbox": image do %>
+                <%# スマホの画像サイズ %>
+                <%= image_tag(image.variant(resize_to_fit: [450,300], gravity: 'Center', strip: true), class: "img d-block mx-auto img-fluid d-sm-none") %>
+                <%# PCの画像サイズ %>
+                <%= image_tag(image.variant(resize_to_fit: [500,415], gravity: 'Center', strip: true), class: "img d-none mx-auto img-fluid d-sm-block") %>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
             </button>
             <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
               <%= link_to edit_post_path(@post), class: 'dropdown-item text-success doropdown-list-delete' do%>
-                  <i class="fas fa-plus"></i>  写真を追加・編集
+                  <i class="fas fa-plus"></i>  <%= t(".edit_images") %>
               <% end %>
             </div>
           </div>
@@ -21,8 +21,8 @@
               <i class="far fa-trash-alt fa-lg"></i>
             </button>
             <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
-              <%= link_to post_path, method: :delete, data: { confirm: 'このログを削除しますか？' }, class: 'dropdown-item text-danger doropdown-list-delete' do %>
-                <span><i class="far fa-trash-alt"></i></span>  ログを削除
+              <%= link_to post_path, method: :delete, data: { confirm: t('defaults.message.delete_confirm', item: Post.model_name.human) }, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                <span><i class="far fa-trash-alt"></i></span>  <%= t(".delete_post") %>
               <% end %>
             </div>
           </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -2,15 +2,15 @@
 
 <div class="container my-4">
   <div class="row justify-content-center">
-    <div class="col-lg-8 col-md-9 p-0">
+    <div class="col-lg-8 col-md-9 col-11 p-0">
       <div class="text-left">
         <%= form_with model: @user, url: profile_path, local: true do |f| %>
           <%= render 'shared/error_messages', object: f.object %>
-          <div class="form-group avatar-panel d-flex justify-content-center pb-2">
-            <div class="prev-img position-relative border-right border-secondary pe-2 pe-sm-5">
-              <%= image_tag 'sample.png', class: "d-block rounded-circle bg-dark-subtle", id: "prev_img" %>
-              <div class="delete-preview">
-                <i class="fas fa-times fa-lg text-white rounded-circle bg-dark opacity-75 p-1 px-sm-2"></i>
+          <div class="form-group avatar-panel d-flex justify-content-evenly justify-content-sm-center pb-2">
+            <div class="prev-img position-relative border-right border-secondary pe-3 pe-sm-4">
+              <%= image_tag @user.avatar, id: 'prev_img', class: "d-block-inline rounded-circle bg-dark-subtle", data: { avatar_url: rails_blob_path(@user.avatar, only_path: true) } if @user.avatar.attached? %>
+              <div class="delete-preview operetion-bg pointer position-absolute top-0 end-0 me-2 mb-2">
+                <i class="fas fa-times text-white d-flex justify-content-center align-items-center h-100 m-0"></i>
               </div>
             </div>
             <%= f.label :avatar, class: "m-0" do %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,48 @@
+<%= javascript_include_tag "avatar-prev.js" %>
+
+<div class="container my-4">
+  <div class="row justify-content-center">
+    <div class="col-lg-8 col-md-9 p-0">
+      <div class="text-left">
+        <%= form_with model: @user, url: profile_path, local: true do |f| %>
+          <%= render 'shared/error_messages', object: f.object %>
+          <div class="form-group avatar-panel d-flex justify-content-center pb-2">
+            <div class="prev-img position-relative border-right border-secondary pe-2 pe-sm-5">
+              <%= image_tag 'sample.png', class: "d-block rounded-circle bg-dark-subtle", id: "prev_img" %>
+              <div class="delete-preview">
+                <i class="fas fa-times fa-lg text-white rounded-circle bg-dark opacity-75 p-1 px-sm-2"></i>
+              </div>
+            </div>
+            <%= f.label :avatar, class: "m-0" do %>
+              <div class="input-area d-flex align-items-center justify-content-center d-block-inline flex-wrap border-dashed border-2 rounded-1 border-secondary pointer ms-3 ms-sm-5">
+                <div class="text-center text-secondary">
+                  <i class="fas fa-camera me-1"></i>画像を
+                  <br>選択する
+                </div>
+              </div>
+              <%= f.file_field :avatar, class: "form-control", :id => 'user_avatar', accept: '.jpeg, .jpg, .png', style: "display: none;" %>
+            <% end %>
+          </div>
+          <div class="form-group">
+            <i class="fas fa-user me-1"></i>
+            <%= f.label :name, class: "fw-bold" %>
+            <%= f.text_field :name, class: 'form-control bg-light', placeholder: User.human_attribute_name(:name) %>
+          </div>
+          <div class="form-group">
+            <i class="fas fa-bicycle"></i>
+            <%= f.label t("users.new.my_bike"), class: "fw-bold text-break", for: "my_bike" %>
+            <%= f.select :my_bike, User.my_bikes.keys, {}, class: 'form-control bg-light', id: "my_bike" %>
+          </div>
+          <div class="form-group">
+            <i class="fas fa-envelope"></i>
+            <%= f.label :bio, class: "fw-bold" %>
+            <%= f.text_area :bio, class: 'form-control bg-light', placeholder: User.human_attribute_name(:bio), rows: 2 %>
+          </div>
+          <div class="form-group">
+            <%= f.submit t("defaults.update"), class: 'btn btn-primary btn-block font-weight-bold rounded-pill mt-4' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -7,11 +7,17 @@
         <%= form_with model: @user, url: profile_path, local: true do |f| %>
           <%= render 'shared/error_messages', object: f.object %>
           <div class="form-group avatar-panel d-flex justify-content-evenly justify-content-sm-center pb-2">
-            <div class="prev-img position-relative border-right border-secondary pe-3 pe-sm-4">
-              <%= image_tag @user.avatar, id: 'prev_img', class: "d-block-inline rounded-circle bg-dark-subtle", data: { avatar_url: rails_blob_path(@user.avatar, only_path: true) } if @user.avatar.attached? %>
+            <div class="prev-img position-relative">
+              <div class="border-right border-secondary pe-3 pe-sm-4">
+                <%= image_tag @user.avatar, id: 'prev_img', class: "d-block-inline rounded-circle bg-dark-subtle", 
+                              data: { avatar_url: rails_blob_path(@user.avatar, only_path: true) } if @user.avatar.attached? %>
+              </div>
               <div class="delete-preview operetion-bg pointer position-absolute top-0 end-0 me-2 mb-2">
                 <i class="fas fa-times text-white d-flex justify-content-center align-items-center h-100 m-0"></i>
               </div>
+              <% if @user.avatar.attached? && @user.avatar.blob.filename.to_s != 'sample.png' %>
+                <%= link_to t("defaults.delete"), profile_attachment_path(@user.avatar.id), method: :delete, class: 'btn btn-danger d-block me-3 me-sm-4 mt-1 p-0' %>
+              <% end %>
             </div>
             <%= f.label :avatar, class: "m-0" do %>
               <div class="input-area d-flex align-items-center justify-content-center d-block-inline flex-wrap border-dashed border-2 rounded-1 border-secondary pointer ms-3 ms-sm-5">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -14,7 +14,7 @@
         <div class="text-left">
           <%= form_with model: @user, local: true do |f| %>
             <%= render 'shared/error_messages', object: f.object %>
-            <div class="form-group avatar-panel d-flex justify-content-center align-items-center pb-2">
+            <div class="form-group avatar-panel d-flex justify-content-center align-items-center flex-wrap pb-2">
               <div class="prev-img position-relative border-right border-secondary pe-3">
                 <%= image_tag 'sample.png', class: "d-block rounded-circle bg-dark-subtle", id: "prev_img" %>
                 <div class="delete-preview">
@@ -38,8 +38,8 @@
             </div>
             <div class="form-group">
               <i class="fas fa-bicycle"></i>
-              <%= f.label t(".my_bike"), class: "fw-bold text-break" %>
-              <%= f.select :my_bike, User.my_bikes.keys, {}, class: 'form-control bg-light' %>
+              <%= f.label t(".my_bike"), class: "fw-bold text-break", for: "my_bike" %>
+              <%= f.select :my_bike, User.my_bikes.keys, {}, class: 'form-control bg-light', id: "my_bike" %>
             </div>
             <div class="form-group">
               <i class="fas fa-envelope"></i>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,10 +1,10 @@
 <%= javascript_include_tag "user-show.js" %>
 
-<div class="container px-lg-5 px-md-4">
-  <div class="row pb-4 mb-5 border-bottom">
+<div class="container px-md-4">
+  <div class="row pb-4 mb-4 border-bottom">
     <div class="user-panel d-flex flex-column flex-md-row justify-content-center align-items-center">
-      <div class="user-avatar d-flex align-items-center mt-3 mb-4">
-        <%= image_tag @user.avatar.variant(gravity: :center, resize: "90x90^!", crop:"90x90+0+0"), class: "rounded-circle bg-dark-subtle me-4", style: "display: inline-block;" %>
+      <div class="user-avatar d-flex align-items-center my-3">
+        <%= image_tag @user.avatar.variant(gravity: :center, resize: "90x90^!", crop:"90x90+0+0"), class: "rounded-circle bg-dark-subtle me-5", style: "display: inline-block;" %>
         <div class="follow-btn mobile-size" style="display: inline-block;">
           <% if @user.id == current_user.id %>
             <div class="item-info mb-2">
@@ -13,10 +13,14 @@
               </button>
               <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
                 <%= link_to users_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                  <div class="fw-bold">
                     <i class="fas fa-book"></i>  <%= t("defaults.to_items_page") %>
+                  </div>
                 <% end %>
                 <%= link_to posts_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                  <div class="fw-bold">
                     <i class="fas fa-search-plus"></i>  <%= t("defaults.to_new_item_page") %>
+                  </div>
                 <% end %>
               </div>
             </div>
@@ -26,11 +30,15 @@
                   <%= t(".setting_profile") %>
                 </button>
                 <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
-                  <%= link_to users_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
-                      <i class="fas fa-id-card"></i>  <%= t("defaults.to_edit_profile_page") %>
+                  <%= link_to edit_profile_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                      <div class="fw-bold">
+                        <i class="fas fa-id-card"></i>  <%= t("defaults.to_edit_profile_page") %>
+                      </div>
                   <% end %>
                   <%= link_to posts_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
-                      <i class="fas fa-lock"></i>  <%= t("defaults.to_reset_page") %>
+                      <div class="fw-bold">
+                        <i class="fas fa-lock"></i>  <%= t("defaults.to_reset_page") %>
+                      </div>
                   <% end %>
                 </div>
               </div>
@@ -40,7 +48,7 @@
           <% end %>
         </div>
       </div>
-      <div class="d-flex flex-column fw-bold me-3">
+      <div class="d-flex flex-column fw-bold">
         <div class="user-element left-line border-4 border-primary ps-3 mb-3 mb-md-0">
           <div class="user-name mb-2">
             <i class="fas fa-user me-1"></i>
@@ -76,10 +84,14 @@
             </button>
             <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
               <%= link_to users_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                <div class="fw-bold">
                   <i class="fas fa-book"></i>  <%= t("defaults.to_items_page") %>
+                </div>
               <% end %>
               <%= link_to posts_path, class: 'dropdown-item text-danger doropdown-list-delete' do %>
+                <div class="fw-bold">
                   <i class="fas fa-search-plus"></i>  <%= t("defaults.to_new_item_page") %>
+                </div>
               <% end %>
             </div>
           </div>
@@ -89,11 +101,15 @@
                 <%= t(".setting_profile") %>
               </button>
               <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
-                <%= link_to users_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                <%= link_to edit_profile_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                  <div class="fw-bold">
                     <i class="fas fa-id-card"></i>  <%= t("defaults.to_edit_profile_page") %>
+                  </div>
                 <% end %>
                 <%= link_to posts_path, class: 'dropdown-item text-secondary doropdown-list-delete' do %>
+                  <div class="fw-bold">
                     <i class="fas fa-lock"></i>  <%= t("defaults.to_reset_page") %>
+                  </div>
                 <% end %>
               </div>
             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,9 @@
   <div class="row pb-4 mb-4 border-bottom">
     <div class="user-panel d-flex flex-column flex-md-row justify-content-center align-items-center">
       <div class="user-avatar d-flex align-items-center my-3">
-        <%= image_tag @user.avatar.variant(gravity: :center, resize: "90x90^!", crop:"90x90+0+0"), class: "rounded-circle bg-dark-subtle me-5", style: "display: inline-block;" %>
+        <%= link_to @user.avatar, "data-lightbox": @user.avatar do %>
+          <%= image_tag @user.avatar.variant(gravity: :center, resize: "90x90^!", crop:"90x90+0+0"), class: "img rounded-circle bg-dark-subtle me-5", style: "display: inline-block;" %>
+        <% end %>
         <div class="follow-btn mobile-size" style="display: inline-block;">
           <% if @user.id == current_user.id %>
             <div class="item-info mb-2">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,9 +63,9 @@
             <%= @user.my_bike_i18n %>
           </div>
           <div class="element-count d-flex flex-wrap">
-            <div class="me-3">フォロワー10件</div>
-            <div class="me-3">フォロー中10件</div>
-            <div>投稿<%= @user.posts.count %>件</div>
+            <div class="me-3"><%= t(".follower") %>10件</div>
+            <div class="me-3"><%= t(".follow") %>10件</div>
+            <div><%= t("defaults.post") %><%= @user.posts.count %>件</div>
           </div>
         </div>
         <div class="bio-area mobile-size fw-bold">
@@ -128,12 +128,14 @@
     </div>
   </div>
 
-  <div class="row mb-4">
+  <div class="row mb-5">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
-      <p class="text-secondary><%= t(".no_post") %></p>
-      <%= link_to 'あなたのログを残そう', new_post_path %>
+      <div class="text-center text-secondary mt-4 mb-5"><%= t(".no_post") %></div>
+      <div class="text-center">
+        <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
+      </div>
     <% end %>
   </div>
 

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -10,12 +10,12 @@ ja:
     my_page: 'マイページ'
     profile: 'プロフィール'
     site: '設定'
-    register: '登録する'
-    post: '投稿する'
-    edit: '編集する'
+    register: '登録'
+    post: '投稿'
+    edit: '編集'
     delete: '削除'
-    submit: '送信する'
-    update: '更新する'
+    submit: '送信'
+    update: '更新'
     follow: 'フォローする'
     unfollow: 'フォロー解除'
     back: '戻る'
@@ -28,6 +28,7 @@ ja:
     to_edit_profile_page: 'プロフィール設定'
     to_reset_page: 'メール・パスワード設定'
     look_password: 'パスワードを表示'
+    select_images: '画像を選択する'
     message:
       require_login: 'ログインしてください'
       created: '%{item}を作成しました'
@@ -57,8 +58,11 @@ ja:
       title: 'ユーザー詳細'
       setting_profile: '登録情報設定'
       item_management: 'アイテム管理'
-      no_post: 'まだ投稿がありません'
+      no_post: 'まだ投稿はありません'
       no_bio: '自己紹介は登録されていません'
+      follow: 'フォロー中'
+      follower: 'フォロワー'
+      leave_log!: 'あなたのログを残そう！'
   user_sessions:
     new:
       title: 'ログイン'
@@ -73,10 +77,13 @@ ja:
     index:
       title: 'ログ一覧'
       no_post: 'ログがまだありません'
+      log_first!: '最初にログを残そう！'
     new:
       title: 'ログ投稿'
     show:
       title: 'ログ詳細'
+      edit_images: '写真を追加・編集'
+      delete_post: 'ログを削除'
     edit:
       title: 'ログ編集'
     bookmarks:

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -13,6 +13,7 @@ ja:
     register: '登録する'
     post: '投稿する'
     edit: '編集する'
+    delete: '削除'
     submit: '送信する'
     update: '更新する'
     follow: 'フォローする'

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -8,6 +8,7 @@ ja:
     likes: 'いいね'
     bookmarks: 'ブックマーク'
     my_page: 'マイページ'
+    profile: 'プロフィール'
     site: '設定'
     register: '登録する'
     post: '投稿する'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[index new create show]
-  resource :profile, only: %i[edit update]
+  resource :profile, only: %i[edit update] do 
+    resources :attachments, controller: 'profile/attachments', only: %i[destroy]
+  end
   resources :posts do
     collection do
       post "upload_image"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
   root 'static_pages#top'
 
-  resources :user_sessions, only: [:new, :create, :destroy]
+  resources :user_sessions, only: %i[new create destroy]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :users, only: [:index, :new, :create, :show]
+  resources :users, only: %i[index new create show]
+  resource :profile, only: %i[edit update]
   resources :posts do
     collection do
       post "upload_image"


### PR DESCRIPTION
## 概要

* プロフィール編集画面の実装
* アバター画像を設定しているユーザーは、プロフィール編集画面内のプレビュー部分にそのアバター画像がプレビューとして表示されるように実装
* アバター削除用のボタンを設置(削除と同時にsample.pngを紐づける)
* ユーザー詳細ページ内のアバター画像と、投稿詳細ページの投稿画像にポップアップ機能を実装


## 確認方法

1. ログイン後、プロフィール編集画面へ遷移しアバター画像と名前、お気に入り自転車メーカー、自己紹介文が編集できることを確認して下さい。
2. アバター画像を設定後、再度プロフィール編集画面へ遷移するとプレビュー部分にその画像が初期値として設定されていることを確認して下さい。
3. デフォルトのsample.png以外の画像データが紐づけられている場合、プレビューの下側にアバター画像削除用のボタンが表示されていることを確認して下さい。
4. アバター削除後、自身のアバター画像がデフォルトの人型になっていることを確認して下さい。
5. ユーザー詳細ページ内のアバター画像と、投稿詳細ページの投稿画像をクリック・タップすると画像が拡大表示(ポップアップ)されることを確認して下さい。


## 以下のissueに関するpull requestです

#21 
