### PR TITLE
Add: 検索結果数・検索結果がない場合の「検索結果がありません」というテキストの表示

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,7 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+    @post_count = @posts.total_count
   end
 
   # GET /posts/new
@@ -59,6 +60,7 @@ class PostsController < ApplicationController
   def likes
     @q = current_user.like_posts.ransack(params[:q])
     @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+    @post_count = @posts.total_count
   end
 
   # 画像アップロード用のアクション

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   def index
     @q = User.ransack(params[:q])
     @users = @q.result(distinct: true).with_attached_avatar.where.not(id: current_user.id).order(created_at: :desc).page(params[:page]).per(15)
+    @user_count = @users.total_count
   end
 
   def new
@@ -33,12 +34,14 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @q = @user.following_users.ransack(params[:q])
     @users = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(15)
+    @user_count = @users.total_count
   end
 
   def followers
     @user = User.find(params[:id])
     @q = @user.follower_users.ransack(params[:q])
     @users = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(15)
+    @user_count = @users.total_count
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,9 @@
 module ApplicationHelper
-
   def nav_item_class(path)
     'active' if current_page?(path)
   end
 
+  def search_from?
+    params[:q].present?
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,11 +1,16 @@
 <div class="container p-2">
-  <div class="title-area under-line border-4 my-2">
+  <div class="title-area d-flex align-items-end under-line border-4 my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
+    <% if search_from? %>
+      <h4 class="ms-auto">
+        <%= t("defaults.search_result") %><%= "#{@post_count}件" %>
+      </h4>
+    <% end %>
   </div>
 
   <!-- 検索フォーム -->
   <div class="row">
-    <%= render 'search_form', q: @q, url: posts_path %>
+    <%= render 'search_form', q: @q, url: posts_path(from_search: @from_search) %>
   </div>
 
   <!-- 掲示板一覧 -->
@@ -13,10 +18,14 @@
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
-      <div class="text-center text-secondary my-5"><%= t(".no_post") %></div>
-      <div class="text-center">
-        <%= link_to t(".log_first!"), new_post_path, class: "btn btn-info" %>
-      </div>
+      <% if search_from? %>
+        <div class="text-center text-secondary my-5"><%= t("defaults.no_search_result") %></div>
+      <% else %>
+        <div class="text-center text-secondary my-5"><%= t(".no_post") %></div>
+        <div class="text-center">
+          <%= link_to t(".log_first!"), new_post_path, class: "btn btn-info" %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,6 +1,11 @@
 <div class="container p-2">
-  <div class="title-area under-line border-4 my-2">
+  <div class="title-area d-flex align-items-end under-line border-4 my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
+    <% if search_from? %>
+      <h4 class="ms-auto">
+        <%= t("defaults.search_result") %><%= "#{@post_count}件" %>
+      </h4>
+    <% end %>
   </div>
 
   <!-- 検索フォーム -->
@@ -13,10 +18,14 @@
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
-      <div class="text-center text-secondary my-5"><%= t(".no_like") %></div>
-      <div class="text-center">
-        <%= link_to t(".lets_like!"), posts_path, class: "btn btn-info" %>
-      </div>
+      <% if search_from? %>
+        <div class="text-center text-secondary my-5"><%= t("defaults.no_search_result") %></div>
+      <% else %>
+        <div class="text-center text-secondary my-5"><%= t(".no_like") %></div>
+        <div class="text-center">
+          <%= link_to t(".lets_like!"), posts_path, class: "btn btn-info" %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,4 +1,12 @@
 <div class="container">
+  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+    <h2 class="fw-bold"><%= t(".title") %></h2>
+    <% if search_from? %>
+      <h4 class="ms-auto">
+        <%= t("defaults.search_result") %><%= "#{@user_count}件" %>
+      </h4>
+    <% end %>
+  </div>
 
   <!-- 検索フォーム -->
   <div class="row">
@@ -24,15 +32,17 @@
         </table>
       </div>
     <% else %>
-      <div class="text-center text-secondary my-5"><%= t(".no_followers") %></div>
-      <% if current_user.id == @user.id %>
-        <div class="text-center">
-          <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
-        </div>
+      <% if search_from? %>
+        <div class="text-center text-secondary my-5"><%= t("defaults.no_search_result") %></div>
+      <% else %>
+        <div class="text-center text-secondary my-5"><%= t(".no_followers") %></div>
+        <% if current_user.id == @user.id %>
+          <div class="text-center">
+            <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>
-
-  
 
 </div>

--- a/app/views/users/follows.html.erb
+++ b/app/views/users/follows.html.erb
@@ -1,4 +1,12 @@
 <div class="container">
+  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+    <h2 class="fw-bold"><%= t(".title") %></h2>
+    <% if search_from? %>
+      <h4 class="ms-auto">
+        <%= t("defaults.search_result") %><%= "#{@user_count}件" %>
+      </h4>
+    <% end %>
+  </div>
 
   <!-- 検索フォーム -->
   <div class="row">
@@ -24,15 +32,17 @@
         </table>
       </div>
     <% else %>
-      <div class="text-center text-secondary my-5"><%= t(".no_follows") %></div>
-      <% if current_user.id == @user.id %>
-        <div class="text-center">
-          <%= link_to t(".lets_follow"), users_path, class: "btn btn-info" %>
-        </div>
+      <% if search_from? %>
+        <div class="text-center text-secondary my-5"><%= t("defaults.no_search_result") %></div>
+      <% else %>
+        <div class="text-center text-secondary my-5"><%= t(".no_follows") %></div>
+        <% if current_user.id == @user.id %>
+          <div class="text-center">
+            <%= link_to t(".lets_follow"), users_path, class: "btn btn-info" %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>
-
-
 
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,12 @@
 <div class="container">
+  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+    <h2 class="fw-bold"><%= t(".title") %></h2>
+    <% if search_from? %>
+      <h4 class="ms-auto">
+        <%= t("defaults.search_result") %><%= "#{@user_count}件" %>
+      </h4>
+    <% end %>
+  </div>
 
   <!-- 検索フォーム -->
   <div class="row">
@@ -24,10 +32,14 @@
         </table>
       </div>
     <% else %>
-      <div class="text-center text-secondary my-5"><%= t(".no_user") %></div>
-      <div class="text-center">
-        <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
-      </div>
+      <% if search_from? %>
+        <div class="text-center text-secondary my-5"><%= t("defaults.no_search_result") %></div>
+      <% else %>
+        <div class="text-center text-secondary my-5"><%= t(".no_user") %></div>
+        <div class="text-center">
+          <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -34,6 +34,8 @@ ja:
     input_user_name: 'ユーザー名を入力'
     select_images: '画像を選択する'
     select_bike: 'メーカーを選択'
+    search_result: '検索結果'
+    no_search_result: '検索結果がありません'
     message:
       require_login: 'ログインしてください'
       created: '%{item}を作成しました'
@@ -50,7 +52,7 @@ ja:
       warning: ログインしてください
   users:
     index:
-      title: 'ユーザー一覧'
+      title: 'ユーザーリスト'
       no_user: '他にユーザーはいません。あなたが最初の利用者です！'
       leave_log!: 'ログを残そう！'
     new:
@@ -72,11 +74,11 @@ ja:
       post: '投稿'
       leave_log!: 'あなたのログを残そう！'
     followers:
-      title:  'フォロワー一覧'
+      title:  'フォロワー'
       no_followers: 'フォロワーはまだいません'
       leave_log!: 'ログを残してフォロワーを増やそう！'
     follows:
-      title:  'フォロー中一覧'
+      title:  'フォロー中'
       no_follows: 'フォロー中のユーザーはいません'
       lets_follow: 'ユーザーをフォローしよう'
   user_sessions:


### PR DESCRIPTION
## 概要

* 投稿・ユーザー検索実行時に検索結果数と、検索結果がない場合は「検索結果がありません」というテキストを表示するようにコードを実装
* 通常のindexアクションの呼び出しか、検索フォームから呼び出されたindexアクションかを区別するためのメソッドをヘルパー内にて定義
* ヘルパー内にて定義したメソッドを使い条件分岐にて、通常のindexアクションと検索フォームからのindexアクションでコンテンツ表示を切り替えるように実装
