### PR TITLE
Remove: 不要ファイルの削除・ログインページの一本化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,6 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    redirect_to login_path, danger: t('defaults.message.require_login')
+    redirect_to root_path, danger: t('defaults.message.require_login')
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,7 +1,5 @@
 class UserSessionsController < ApplicationController
-  skip_before_action :require_login, only: %i[new create]
-
-  def new; end
+  skip_before_action :require_login, only: %i[create]
 
   def create
     @user = login(params[:email], params[:password])

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,0 @@
-module PostsHelper
-end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,2 +1,0 @@
-module StaticPagesHelper
-end

--- a/app/helpers/user_sessions_helper.rb
+++ b/app/helpers/user_sessions_helper.rb
@@ -1,2 +1,0 @@
-module UserSessionsHelper
-end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,0 @@
-module UsersHelper
-end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,8 +4,5 @@
 
 import { application } from "./application"
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
-
 import ImagesController from "./images_controller"
 application.register("images", ImagesController)

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,8 +1,0 @@
-<div class="container">
-  <div class="row justify-content-center">
-    <div class="col-xl-5 col-lg-6 col-md-8 col-sm-10 col-12 px-md-4 mb-4">
-      <%= render "form" %>
-      <%= link_to t("defaults.to_top_page"), root_path, class: "text-decoration-none" %>
-    </div>
-  </div>
-</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -68,10 +68,9 @@
           <i class="fas fa-arrow-alt-circle-down ms-1 mb-3"></i>
         </div>
         <div class="text-center">
-          <%= link_to t("defaults.to_login_page"), login_path, class: "btn btn-outline-info btn-block font-weight-bold rounded-pill mb-3" %>
+          <%= link_to t("defaults.to_login_page"), root_path, class: "btn btn-outline-info btn-block font-weight-bold rounded-pill mb-3" %>
         </div>
       </div>
-      <%= link_to t("defaults.to_top_page"), root_path, class: "text-decoration-none" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,7 @@ Rails.application.routes.draw do
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms', to: 'static_pages#terms'
 
-  resources :user_sessions, only: %i[new create destroy]
-  get 'login', to: 'user_sessions#new'
+  resources :user_sessions, only: %i[create destroy]
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 


### PR DESCRIPTION
## 概要

* 不要ファイルの削除
* これまではトップページとログインページの二つのページからログインできるようにしていたが、トップページからのみログインできるように`user_sessions/new.html.erb`を削除
* `login_path`へのリンク全てをトップページに遷移する`root_path`に置き換えた
* ルーティング、コントローラーの不要なコードを削除


