### PR TITLE
Add: ヘッダーに動的にタイトルが表示されるように実装

### DIFF
--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,7 +1,7 @@
-<div class="container">
+<div class="container mb-5">
   <div class="row justify-content-center">
     <div class="col-xl-8 col-lg-9 col-md-10 col-12">     
-      <div class="title-area text-center mt-4 mb-5">
+      <div class="title-area text-center d-lg-block d-none mt-4 mb-5">
         <h3 class="fw-bold"><%= t(".title") %></h3>
       </div>
       <div class="form-area border rounded bg-body-secondary px-4 py-4 px-sm-5">

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,7 +1,7 @@
-<div class="container">
+<div class="container mb-5">
   <div class="row justify-content-center">
     <div class="col-xl-7 col-lg-8 col-md-10 col-12">
-      <div class="title-area text-center mt-4 mb-5">
+      <div class="title-area text-center d-lg-block d-none mt-4 mb-5">
         <h3 class="fw-bold"><%= t(".title") %></h3>
       </div>
       <div class="form-area border rounded bg-body-secondary px-4 py-5 p-sm-5">

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid p-0">
-  <div class="title-area under-line border-4 my-2">
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
   

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,12 +1,13 @@
 <div class="container p-2">
-  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
-    <% if search_from? %>
-      <h4 class="ms-auto">
-        <%= t("defaults.search_result") %>:<%= "#{@post_count}件" %>
-      </h4>
-    <% end %>
   </div>
+
+  <% if search_from? %>
+    <h4 class="text-center my-4 my-lg-5">
+      <%= t("defaults.search_result") %>:<%= "#{@post_count}件" %>
+    </h4>
+  <% end %>
 
   <!-- 検索フォーム -->
   <div class="row">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid p-0">
-  <div class="title-area under-line border-4 my-2">
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,34 +1,6 @@
 <div class='container-fluid px-1'>
-  <div class="operation-area d-flex my-2">
-    <div class="dropdown-btn ms-auto">
-      <% if current_user.own?(@post) %>
-        <div class="add-element float-left">
-          <div class="dropleft">
-            <button class="btn btn-light dropdown-toggle border" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class="far fa-plus-square fa-lg"></i>
-            </button>
-            <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
-              <%= link_to edit_post_path(@post), class: 'dropdown-item text-success doropdown-list-delete' do%>
-                  <i class="fas fa-plus"></i>  <%= t(".edit_images") %>
-              <% end %>
-            </div>
-          </div>
-        </div>
-
-        <div class="delete-element float-left ps-1">
-          <div class="dropleft">
-            <button class="btn btn-light dropdown-toggle border" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class="far fa-trash-alt fa-lg"></i>
-            </button>
-            <div class="dropdown-menu bg-white" aria-labelledby="dropdownMenuButton">
-              <%= link_to post_path, method: :delete, data: { confirm: t('defaults.message.delete_confirm', item: Post.model_name.human) }, class: 'dropdown-item text-danger doropdown-list-delete' do %>
-                <span><i class="far fa-trash-alt"></i></span>  <%= t(".delete_post") %>
-              <% end %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+    <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 
   <div class="card shadow">
@@ -42,10 +14,13 @@
         <div class="user-name d-flex align-items-center text-break">
           <%= link_to @post.user.name, user_path(@post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
         </div>
-        <span class="text-secondary mx-2">
-          <i class="far fa-clock clock-icon me-1">
-          </i><%= time_ago_in_words(@post.created_at) %>前
-        </span>
+        <div class="operation_area d-flex align-items-center ml-auto">
+          <% if current_user.own?(@post) %>
+            <%= render 'posts/crud_menus', post: @post %>
+          <% else %>
+            <%= render 'posts/like_button', post: @post %>
+          <% end %>
+        </div>
       </div>
     </div>
 
@@ -77,7 +52,14 @@
     <% end %>
 
     <div class="card-body ms-2">
-      <h4 class="card-title fw-bold m-0"><%= @post.title %></h4><br>
+      <div class="d-flex align-items-center">
+        <h4 class="card-title fw-bold m-0"><%= @post.title %></h4>
+        <div class="text-secondary ms-2 mt-auto">
+          <i class="far fa-clock clock-icon me-1">
+          </i><%= time_ago_in_words(@post.created_at) %>前
+        </div>
+      </div>
+      <br>
       <p class="card-text"><%= @post.content %></p>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
           <i class="fas fa-angle-left fa-2x text-dark mx-3"></i>
         <% end %>
       <% end %>
-      <h5 class="page-title d-lg-none fw-bold mx-auto my-2">
+      <h5 class="page-title d-lg-none fw-bold mx-auto my-2 <%= logged_in? ? '' : 'pe-5' %>">
         <%= t("#{controller_name}.#{action_name}.title") %>
       </h5>
     <% else %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,27 @@
-<nav class="navbar navbar-expand-lg navbar-light px-4">
+<nav class="navbar navbar-expand-lg navbar-light px-3">
   <div class="container-fluid px-0">
-    <%= link_to root_path, class: "navbar-brand" do %>
-      <%= image_tag 'chari-log-logo.png', class: "ms-2", style: "height: 45px;" %>
+    
+    <!-- PCサイズ以上 -->
+    <%= link_to root_path, class: "navbar-brand d-lg-block d-none p-0" do %>
+      <%= image_tag 'chari-log-logo.png', class: "ms-3", style: "height: 45px;" %>
     <% end %>
+
+    <!-- タブレットサイズ以下 -->
+    <% unless current_page?(posts_path) || current_page?(root_path) %>
+      <% unless controller_name == 'password_resets' && action_name == 'edit' %>
+        <%= link_to 'javascript:history.back()', class:"d-lg-none" do %>
+          <i class="fas fa-angle-left fa-2x text-dark mx-3"></i>
+        <% end %>
+      <% end %>
+      <h5 class="page-title d-lg-none fw-bold mx-auto my-2">
+        <%= t("#{controller_name}.#{action_name}.title") %>
+      </h5>
+    <% else %>
+      <%= link_to root_path, class: "navbar-brand mx-2 p-0" do %>
+        <%= image_tag 'chari-log-logo.png', class: "d-lg-none", style: "height: 40px;" %>
+      <% end %>
+    <% end %>
+
     <% if logged_in? %>
       <div class="user-panel d-lg-flex d-none align-items-center">
         <div class="user-avatar mx-2">

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <section class="section">
       <div class="content">
-        <h2 class="text-center my-4">プライバシーポリシー</h2>
+        <h2 class="text-center fw-bold d-lg-block d-none my-4">プライバシーポリシー</h2>
 
         <h5 class="fw-bold">お客様から取得する情報</h3>
         <p>当社は、お客様から以下の情報を取得します。</p>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <section class="section">
       <div class="content">
-        <h2 class="text-center my-4">利用規約</h2>
+        <h2 class="text-center fw-bold d-lg-block d-none my-4">利用規約</h2>
         <p>本規約は、（以下「当社」といいます。）が提供する「ChariLog」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>
 
         <h5 class="fw-bold pt-4">第一条（規約の適用）</h5>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,12 +1,13 @@
 <div class="container">
-  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
-    <% if search_from? %>
-      <h4 class="ms-auto">
-        <%= t("defaults.search_result") %>:<%= "#{@user_count}件" %>
-      </h4>
-    <% end %>
   </div>
+  
+  <% if search_from? %>
+    <h4 class="text-center my-4 my-lg-5">
+      <%= t("defaults.search_result") %>:<%= "#{@user_count}件" %>
+    </h4>
+  <% end %>
 
   <!-- 検索フォーム -->
   <div class="row">

--- a/app/views/users/follows.html.erb
+++ b/app/views/users/follows.html.erb
@@ -1,12 +1,13 @@
 <div class="container">
-  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
-    <% if search_from? %>
-      <h4 class="ms-auto">
-        <%= t("defaults.search_result") %>:<%= "#{@user_count}件" %>
-      </h4>
-    <% end %>
   </div>
+
+  <% if search_from? %>
+    <h4 class="text-center my-4 my-lg-5">
+      <%= t("defaults.search_result") %>:<%= "#{@user_count}件" %>
+    </h4>
+  <% end %>
 
   <!-- 検索フォーム -->
   <div class="row">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,12 +1,13 @@
 <div class="container">
-  <div class="title-area d-flex align-items-end under-line border-4 my-2">
+  <div class="title-area under-line border-4 d-lg-block d-none my-2">
     <h2 class="fw-bold"><%= t(".title") %></h2>
-    <% if search_from? %>
-      <h4 class="ms-auto">
-        <%= t("defaults.search_result") %>:<%= "#{@user_count}件" %>
-      </h4>
-    <% end %>
   </div>
+
+  <% if search_from? %>
+    <h4 class="text-center my-4 my-lg-5">
+      <%= t("defaults.search_result") %>:<%= "#{@user_count}件" %>
+    </h4>
+  <% end %>
 
   <!-- 検索フォーム -->
   <div class="row">

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -52,7 +52,12 @@ ja:
       not_authorized: '権限がありません'
   application:
     not_authenticated:
-      warning: ログインしてください
+      warning: 'ログインしてください'
+  static_pages:
+    terms:
+      title: '利用規約'
+    privacy_policy:
+      title: 'プライバシーポリシー'
   users:
     index:
       title: 'ユーザーリスト'
@@ -115,11 +120,13 @@ ja:
       lets_like!: 'ログをいいねしよう！'
   items:
     index:
-
+      title:
+    search:
+      title: 'アイテム検索・登録'
     create:
-
+      title:
     destroy:
-
+      title:
   profiles:
     show:
       title: 'マイページ'


### PR DESCRIPTION
## 概要

* 画面サイズがタブレット以下の場合、ヘッダー内にタイトルと戻るボタンが表示されるように実装
* タブレットサイズ以下の場合、メインコンテンツ内のタイトルが非表示になるように実装

## 確認方法

1. 画面サイズを575px以下にすると、ログイン前のトップページとログイン後のログ一覧ページを除くすべてのページにいる場合、ヘッダー内にそのページに対応したタイトルと戻るボタンが表示されるので確認して下さい。
2. ユーザー詳細ページに関しては、自分以外のユーザ詳細と自分のユーザー詳細を区別して異なるタイトルが表示されるので確認して下さい。

## 以下のissueに関するpull requestです

#72 