### PR TITLE
Fix: トップページ内の最新の投稿が縦積みになる問題を解消・いいねカウントの折り返しを禁止

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
             </div>
 
             <!-- メインコンテンツ -->
-            <div class="content-wrapper col-xl-10 col-lg-10 col-md-12 bg-white px-1 px-sm-5 pt-4 z-0">
+            <div class="content-wrapper col-xl-10 col-lg-10 col-md-12 bg-white px-4 px-sm-5 pt-4 z-0">
               <%= render "/shared/flash_message" %>
               <%= yield %>
               <div class="mask-area overlay"></div>

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -5,5 +5,5 @@
             method: :post,
             remote: true do %>
   <i class="far fa-heart heart-empty text-dark"></i>
-  <div class="text-secondary"><%= post.likes.count %> Likes</div>
+  <div class="text-secondary text-nowrap"><%= post.likes.count %> Likes</div>
 <% end %>

--- a/app/views/posts/_unlike.html.erb
+++ b/app/views/posts/_unlike.html.erb
@@ -5,5 +5,5 @@
             method: :delete, 
             remote: true do %>
   <i class="fas fa-heart heart"></i>
-  <div class="text-secondary"><%= post.likes.count %> Likes</div>
+  <div class="text-secondary text-nowrap"><%= post.likes.count %> Likes</div>
 <% end %>

--- a/app/views/static_pages/_post_list.html.erb
+++ b/app/views/static_pages/_post_list.html.erb
@@ -1,5 +1,5 @@
 <% @posts.each do |post| %>
-  <div class="col-sm-6 col-lg-4 text-center mb-3">
+  <div class="col-12 col-md-6 col-lg-4 text-center mb-3">
     <div class="card shadow-sm">
       <div class="header-area">
         <div class="container">
@@ -14,7 +14,7 @@
             </div>
             <div class="like_count align-items-center ml-auto">
               <i class="far fa-heart heart"></i>
-              <div class="text-secondary"><%= post.likes.count %> Likes</div>
+              <div class="text-secondary text-nowrap"><%= post.likes.count %> Likes</div>
             </div>
           </div>
         </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -39,8 +39,7 @@
           あなたもマイバイクとのログを残そう！
         </p>
       </div>
-
-      <div class="post-list">
+      <div class="d-flex flex-wrap justify-content-center">
         <%= render 'post_list' %>
       </div>
     </div>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -136,7 +136,7 @@ ja:
       title: 'プロフィール編集'
   password_resets:
     new:
-      title: 'メール・パスワード再設定申請'
+      title: 'パスワード再設定申請'
       require_email: 'メールアドレスを入力して下さい'
       to_edit_password_reset_page: '再設定手続きを進める'
     edit:


### PR DESCRIPTION
## 概要

* トップページ内の最新の投稿が縦積みになる問題を解消
* いいねカウントの折り返しを禁止
* その他日本語化対応/余白調整
