### PR TITLE
Fix: ユーザー詳細ページの記述に条件分岐を追加・余白調整/メインコンテンツ内のタイトルに戻るボタンを追加

### DIFF
--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,10 +1,11 @@
-<div class="container-fluid p-0">
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+<div class="container-fluid p-0 mb-5">
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
   
   <%= render 'form', post: @post %>
 
 </div>
-
-<%= link_to 'Back', posts_path %>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,5 +1,8 @@
 <div class="container p-2">
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,10 +1,11 @@
-<div class="container-fluid p-0">
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+<div class="container-fluid p-0 mb-5">
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 
   <%= render 'form', post: @post %>
   
 </div>
-
-<%= link_to 'Back', posts_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,8 @@
-<div class='container-fluid px-1'>
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+<div class='container-fluid px-1 mb-5'>
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,10 +1,10 @@
 <main>
-  <div class="container">
+  <div class="container mb-5">
     <section class="section">
       <div class="content">
         <h2 class="text-center fw-bold d-lg-block d-none my-4">プライバシーポリシー</h2>
 
-        <h5 class="fw-bold">お客様から取得する情報</h3>
+        <h5 class="fw-bold pt-3">お客様から取得する情報</h3>
         <p>当社は、お客様から以下の情報を取得します。</p>
         <ul>
           <li>氏名(ニックネームやペンネームも含む)</li>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,9 +1,9 @@
 <main>
-  <div class="container">
+  <div class="container mb-5">
     <section class="section">
       <div class="content">
         <h2 class="text-center fw-bold d-lg-block d-none my-4">利用規約</h2>
-        <p>本規約は、（以下「当社」といいます。）が提供する「ChariLog」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>
+        <p class="pt-3">本規約は、（以下「当社」といいます。）が提供する「ChariLog」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>
 
         <h5 class="fw-bold pt-4">第一条（規約の適用）</h5>
         <ol>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,5 +1,8 @@
 <div class="container">
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
   

--- a/app/views/users/follows.html.erb
+++ b/app/views/users/follows.html.erb
@@ -1,5 +1,8 @@
 <div class="container">
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,8 @@
-<div class="container">
-  <div class="title-area under-line border-4 d-lg-block d-none my-2">
+<div class="container mb-5">
+  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
+    <%= link_to 'javascript:history.back()' do %>
+      <i class="fas fa-angle-left fa-2x me-4"></i>
+    <% end %>
     <h2 class="fw-bold"><%= t(".title") %></h2>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -92,9 +92,11 @@
       <%= render @posts %>
     <% else %>
       <div class="text-center text-secondary mt-4 mb-5"><%= t(".no_post") %></div>
-      <div class="text-center">
-        <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
-      </div>
+      <% if current_user.id == @user.id %>
+        <div class="text-center">
+          <%= link_to t(".leave_log!"), new_post_path, class: "btn btn-info" %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 


### PR DESCRIPTION
## 概要

* ユーザー詳細ページのログがない場合の「ログを残そう!」という文言をcurrent_userのみに表示するよう条件分岐を実装
* 一部メインコンテンツの下部に余白を追加
* 画面サイズPC以上の時のメインコンテンツ内のタイトルに戻るボタンを追加
