### PR TITLE
Add: ログ一覧といいね一覧に並べ替え機能を追加

### DIFF
--- a/app/views/posts/_sort_posts_menu.html.erb
+++ b/app/views/posts/_sort_posts_menu.html.erb
@@ -1,0 +1,20 @@
+<div class="btn-group dropdown ms-auto border">
+  <button class="btn btn-lg dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+    並び替え
+  </button>
+  <ul class="dropdown-menu dropdown-menu-end" id="dropdown_menu" aria-labelledby="dropdownMenuButton1">
+    <% if current_page?(posts_path) %>
+      <li><%= link_to "新着順", posts_path(order: 'new'), class: "active dropdown-item text-dark" %></li>
+      <li><%= link_to "古い順", posts_path(order: 'old'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "タイトル(降順)", posts_path(order: 'title_desc'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "タイトル(昇順)", posts_path(order: 'title_asc'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "人気順", posts_path(order: 'like_desc'), class: "dropdown-item text-dark" %></li>
+    <% elsif current_page?(likes_posts_path) %>
+      <li><%= link_to "新着順", likes_posts_path(order: 'new'), class: "active dropdown-item text-dark" %></li>
+      <li><%= link_to "古い順", likes_posts_path(order: 'old'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "タイトル(降順)", likes_posts_path(order: 'title_desc'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "タイトル(昇順)", likes_posts_path(order: 'title_asc'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "人気順", likes_posts_path(order: 'like_desc'), class: "dropdown-item text-dark" %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,17 +1,20 @@
 <div class="container p-2">
   <div class="title-area d-flex flex-wrap align-items-center justify-content-center under-line border-4 my-2">
-    <h3 class="fw-bold"><%= t(".title") %></h3>
-    <% if search_from? %>
-      <h4 class="ms-auto">
-        <%= t("defaults.search_result") %>:<%= "#{@post_count}件" %>
-      </h4>
-    <% end %>
+    <h4 class="fw-bold m-0"><%= t(".title") %></h4>
+    <!-- 並び替えリスト -->
+    <%= render 'sort_posts_menu' %>
   </div>
 
   <!-- 検索フォーム -->
   <div class="row">
-    <%= render 'search_form', q: @q, url: posts_path(from_search: @from_search) %>
+    <%= render 'search_form', q: @q, url: likes_posts_path %>
   </div>
+
+  <% if search_from? %>
+    <h4 class="text-center my-4">
+      <%= t("defaults.search_result") %>:<%= "#{@post_count}件" %>
+    </h4>
+  <% end %>
 
   <!-- 掲示板一覧 -->
   <div class="row mb-5">

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,21 +1,24 @@
 <div class="container p-2">
-  <div class="title-area under-line border-4 d-lg-flex d-none my-2">
-    <%= link_to 'javascript:history.back()' do %>
+  <div class="title-area d-flex flex-wrap align-items-center justify-content-center under-line border-4 my-2">
+    <%= link_to 'javascript:history.back()', class: "d-lg-flex d-none" do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>
     <% end %>
-    <h3 class="fw-bold"><%= t(".title") %></h3>
-  </div>
+    <h4 class="fw-bold m-0"><%= t(".title") %></h4>
 
-  <% if search_from? %>
-    <h4 class="text-center my-4 my-lg-5">
-      <%= t("defaults.search_result") %>:<%= "#{@post_count}件" %>
-    </h4>
-  <% end %>
+    <!-- 並び替えリスト -->
+    <%= render 'sort_posts_menu' %>
+  </div>
 
   <!-- 検索フォーム -->
   <div class="row">
     <%= render 'search_form', q: @q, url: likes_posts_path %>
   </div>
+
+  <% if search_from? %>
+    <h4 class="text-center my-4">
+      <%= t("defaults.search_result") %>:<%= "#{@post_count}件" %>
+    </h4>
+  <% end %>
 
   <!-- 掲示板一覧 -->
   <div class="row mb-5">


### PR DESCRIPTION
## 概要

* ログ一覧といいね一覧に並べ替え機能を追加


## 確認方法

1. ログ一覧といいね一覧のタイトル右横にある並べ替えと記載されたドロップボタンから、特定の選択肢を選ぶとその通りに並びが変わるので確認して下さい。

## 以下のissueに関するpull requestです

#70
