### PR TITLE
Add: 投稿全体にいいねボタンとは別でいいねマークとカウントを追加

### DIFF
--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,1 +1,2 @@
+$("#likes-count-<%= @post.id %>").html("<%= @post.likes.count %>");
 $("#js-like-button-for-post-<%= @post.id %>").replaceWith("<%= j(render('posts/unlike', post: @post)) %>");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,1 +1,2 @@
+$("#likes-count-<%= @post.id %>").html("<%= @post.likes.count %>");
 $("#js-like-button-for-post-<%= @post.id %>").replaceWith("<%= j(render('posts/like', post: @post)) %>");

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -45,7 +45,15 @@
         <%= image_tag "no_image.png", class: "d-block mx-auto img-fluid hover-opacity-75 border-top border-bottom", style: "height: auto; width: auto;" %>
       <% end %>
 
-      <div class="card-body hover-opacity-50">
+      <div class="card-body hover-opacity-50 pt-3">
+        <div class="like-count d-flex align-items-center h4 mb-3">
+          <ion-icon name="heart-circle-outline"></ion-icon>
+          <div class="text-secondary">
+            <div id="likes-count-<%= post.id %>">
+              <%= post.likes.count %>
+            </div>
+          </div>
+        </div>
         <h5 class="card-title fw-bold"><%= post.title %></h5>
         <p class="card-text m-0"><%= post.content.truncate(30) %></p>
         <span class="text-secondary">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid p-0 mb-5">
+<div class="container pt-2 mb-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,4 @@
-<div class='container-fluid px-1 mb-5'>
+<div class='container pt-2 mb-5'>
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>


### PR DESCRIPTION
## 概要

* これまでの実装内容では自身の各投稿のいいね数を確認することができなかったので、投稿全体にいいねボタンとは別でいいねマークとカウントを追加
