### PR TITLE
Fix: デザイン調整・ユーザー登録時の注意書き追加・N+1問題の解消等

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,6 +58,10 @@ body {
   opacity: 0.5;
 }
 
+.font-mini-size {
+  font-size: 13px;
+}
+
 .over-line {
   &.border-1 {
     border-top: 1px solid;

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex align-items-center ps-0">
       <div class="user-avatar mx-2">
         <%= link_to user_path(current_user) do %>
-          <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+          <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
         <% end %>
       </div>
       <div class="name_field text-break">
@@ -39,7 +39,7 @@
         </div>
 
         <div class="form-group">
-          <%= f.label :images, class: "input-area text-center d-block w-100 border-dashed border-2 rounded-1 border-success pointer py-2 py-lg-4", for: "file-upload" do %>
+          <%= f.label :images, class: "input-area text-center d-block w-100 border-dashed border-2 rounded-1 border-success pointer hover-opacity-75 py-2 py-lg-4", for: "file-upload" do %>
             <span class="text-center text-success">
               <i class="fas fa-camera me-2"></i><%= t("defaults.select_images") %>
             </span>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -48,7 +48,7 @@
       <div class="card-body hover-opacity-50 pt-3">
         <div class="like-count d-flex align-items-center h4 mb-3">
           <ion-icon name="heart-circle-outline"></ion-icon>
-          <div class="text-secondary">
+          <div class="text-secondary ms-1">
             <div id="likes-count-<%= post.id %>">
               <%= post.likes.count %>
             </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,7 +5,7 @@
         <div class="user-panel d-flex align-items-center py-2">
           <div class="user-avatar me-2">
             <%= link_to user_path(post.user) do %>
-              <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+              <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
             <% end %>
           </div>
           <div class="user-name d-flex align-items-center text-break">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
       <div class="d-flex align-items-center">
         <div class="user-avatar me-2 sm-mx-2">
           <%= link_to user_path(@post.user) do %>
-            <%= image_tag @post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+            <%= image_tag @post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
           <% end %>
         </div>
         <div class="user-name d-flex align-items-center text-break">
@@ -36,9 +36,9 @@
             <div class="swiper-slide">
               <%= link_to image, "data-lightbox": image do %>
                 <%# スマホの画像サイズ %>
-                <%= image_tag(image.variant(resize_to_fit: [450,300], gravity: 'Center', strip: true), class: "img d-block mx-auto img-fluid d-sm-none") %>
+                <%= image_tag(image.variant(resize_to_fit: [450,300], gravity: 'Center', strip: true), class: "img d-block mx-auto img-fluid d-sm-none hover-opacity-75") %>
                 <%# PCの画像サイズ %>
-                <%= image_tag(image.variant(resize_to_fit: [500,415], gravity: 'Center', strip: true), class: "img d-none mx-auto img-fluid d-sm-block") %>
+                <%= image_tag(image.variant(resize_to_fit: [500,415], gravity: 'Center', strip: true), class: "img d-none mx-auto img-fluid d-sm-block hover-opacity-75") %>
               <% end %>
             </div>
           <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,4 @@
-<div class='container pt-2 mb-5'>
+<div class='container p-0 pb-4 mb-5'>
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>
@@ -54,16 +54,21 @@
       <%= image_tag "no_image.png", class: "d-block mx-auto img-fluid hover-opacity-75 border-top border-bottom m-0", style: "height: auto; width: auto;" %>
     <% end %>
 
-    <div class="card-body ms-2">
-      <div class="d-flex align-items-center">
-        <h4 class="card-title fw-bold m-0"><%= @post.title %></h4>
-        <div class="text-secondary ms-2 mt-auto">
-          <i class="far fa-clock clock-icon me-1">
-          </i><%= time_ago_in_words(@post.created_at) %>前
+    <div class="card-body ms-2 pt-3">
+      <div class="like-count d-flex align-items-center h4 mb-3">
+        <ion-icon name="heart-circle-outline"></ion-icon>
+        <div class="text-secondary ms-1">
+          <div id="likes-count-<%= @post.id %>">
+            <%= @post.likes.count %>
+          </div>
         </div>
       </div>
-      <br>
+      <h4 class="card-title fw-bold m-0"><%= @post.title %></h4>
       <p class="card-text"><%= @post.content %></p>
+      <span class="text-secondary">
+        <i class="far fa-clock clock-icon me-1">
+        </i><%= time_ago_in_words(@post.created_at) %>前
+      </span>
     </div>
   </div>
 </div>  

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -20,7 +20,7 @@
               <% end %>
             </div>
             <%= f.label :avatar, class: "m-0" do %>
-              <div class="input-area d-flex align-items-center justify-content-center d-block-inline flex-wrap border-dashed border-2 rounded-1 border-secondary pointer ms-3 ms-sm-5">
+              <div class="input-area d-flex align-items-center justify-content-center d-block-inline flex-wrap border-dashed border-2 rounded-1 border-secondary pointer hover-opacity-75 ms-3 ms-sm-5">
                 <div class="text-center text-secondary">
                   <i class="fas fa-camera me-1"></i>画像を
                   <br>選択する
@@ -32,17 +32,17 @@
           <div class="form-group">
             <i class="fas fa-user me-1"></i>
             <%= f.label :name, class: "fw-bold" %>
-            <%= f.text_field :name, class: 'form-control bg-white', placeholder: User.human_attribute_name(:name) %>
+            <%= f.text_field :name, class: 'form-control bg-light', placeholder: User.human_attribute_name(:name) %>
           </div>
           <div class="form-group">
             <i class="fas fa-bicycle"></i>
             <%= f.label t("users.new.my_bike"), class: "fw-bold text-break", for: "my_bike" %>
-            <%= f.select :my_bike, User.my_bikes.keys, {}, class: 'form-control bg-white', id: "my_bike" %>
+            <%= f.select :my_bike, User.my_bikes.keys, {}, class: 'form-control bg-light', id: "my_bike" %>
           </div>
           <div class="form-group">
             <i class="fas fa-envelope"></i>
             <%= f.label :bio, class: "fw-bold" %>
-            <%= f.text_area :bio, class: 'form-control bg-white', placeholder: User.human_attribute_name(:bio), rows: 2 %>
+            <%= f.text_area :bio, class: 'form-control bg-light', placeholder: User.human_attribute_name(:bio), rows: 2 %>
           </div>
           <div class="form-group">
             <%= f.submit t("defaults.update"), class: 'btn btn-primary btn-block font-weight-bold rounded-pill mt-4' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,10 +3,10 @@
     <div class='row'>
       <div class='col-md-12 text-center'>
         <br>
-        <%= link_to t("defaults.terms"), '/terms', class: 'text-secondary fs-5 m-2'%>
-        <%= link_to t("defaults.privacy_policy"), '/privacy_policy', class: 'text-secondary fs-5 text-nowrap m-2'%>
-        <%= link_to t("defaults.inquiry"), 'https://docs.google.com/forms/d/e/1FAIpQLSeHZcjha6HuQH0mcEN8ZAkv8ZMQY2p7YJCNxAFFcl1zUN_wkQ/viewform', class: "text-secondary fs-5 text-nowrap m-2" %>
-        <p class='text-secondary mt-2'>© 2024. ChariLog.</p>
+        <%= link_to t("defaults.terms"), '/terms', class: 'text-secondary fs-5 m-2', style: "text-decoration:none;" %>
+        <%= link_to t("defaults.privacy_policy"), '/privacy_policy', class: 'text-secondary text-nowrap fs-5 m-2', style: "text-decoration:none;" %>
+        <%= link_to t("defaults.inquiry"), 'https://docs.google.com/forms/d/e/1FAIpQLSeHZcjha6HuQH0mcEN8ZAkv8ZMQY2p7YJCNxAFFcl1zUN_wkQ/viewform', class: "text-secondary text-nowrap fs-5 m-2", style: "text-decoration:none;" %>
+        <p class='text-secondary fs-5 mt-2'>© 2024. ChariLog.</p>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -34,11 +34,11 @@
       <div class="user-panel d-lg-flex d-none align-items-center">
         <div class="user-avatar mx-2">
           <%= link_to user_path(current_user) do %>
-            <%= image_tag current_user.avatar.variant(gravity: :center, resize: "40x40^!", crop:"40x40+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+            <%= image_tag current_user.avatar.variant(gravity: :center, resize: "40x40^!", crop:"40x40+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
           <% end %>
         </div>
         <div class="user-name">
-          <%= link_to current_user.name, user_path(current_user), class: "d-block font-weight-bold text-secondary" %>
+          <%= link_to current_user.name, user_path(current_user), class: "d-block font-weight-bold text-secondary", style: "text-decoration:none;" %>
         </div>
         <div class="new-post-btn ms-4">
           <%= link_to t("defaults.post"), new_post_path, class: "btn btn-sm btn-info fw-bold px-3 py-2" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,7 +14,15 @@
         <% end %>
       <% end %>
       <h5 class="page-title d-lg-none fw-bold mx-auto my-2 <%= logged_in? ? '' : 'pe-5' %>">
-        <%= t("#{controller_name}.#{action_name}.title") %>
+        <% if logged_in? %>
+          <% unless current_page?(user_path(current_user)) %>
+            <%= t("#{controller_name}.#{action_name}.title") %>
+          <% else %>
+            <%= t("#{controller_name}.#{action_name}.mypage") %>
+          <% end %>
+        <% else %>
+          <%= t("#{controller_name}.#{action_name}.title") %>
+        <% end %>
       </h5>
     <% else %>
       <%= link_to root_path, class: "navbar-brand mx-2 p-0" do %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -5,7 +5,7 @@
         <div class="user-panel d-flex align-items-center mb-2">
           <div class="user-avatar me-2">
             <%= link_to user_path(current_user) do %>
-              <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+              <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
             <% end %>
           </div>
           <div class="user-name">

--- a/app/views/static_pages/_post_list.html.erb
+++ b/app/views/static_pages/_post_list.html.erb
@@ -12,9 +12,13 @@
             <div class="user-name d-flex align-items-center text-break">
               <%= link_to post.user.name, user_path(post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
             </div>
-            <div class="like_count align-items-center ml-auto">
-              <i class="far fa-heart heart"></i>
-              <div class="text-secondary text-nowrap"><%= post.likes.count %> Likes</div>
+            <div class="like_count d-flex align-items-center ml-auto text-danger h4 mb-0">
+              <ion-icon name="heart-circle-outline"></ion-icon>
+              <div class="text-secondary ms-1">
+                <div id="likes-count-<%= post.id %>">
+                  <%= post.likes.count %>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,14 +1,18 @@
 <tr>
   <th class="text-center">
     <%= link_to user_path(user) do %>
-      <%= image_tag user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+      <%= image_tag user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
     <% end %>
   </th>
   <th class="align-middle">
     <%= link_to user.name, user_path(user), class: "text-nowrap text-dark hover-opacity-50", style: "text-decoration:none;" %>
   </th>
   <th class="align-middle">
-    <div class="text-nowrap"><%= user.my_bike_i18n %></div>
+    <% if user.my_bike.present? %>
+      <div class="text-nowrap"><%= user.my_bike_i18n %></div>
+    <% else %>
+      <div class="text-info text-nowrap"><%= t("defaults.no_mybike") %></div>
+    <% end %>
   </th>
   <th class="align-middle">
     <% if current_user != user %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -57,6 +57,9 @@
               <%= f.label :password_confirmation, class: "fw-bold require" %>
               <%= f.password_field :password_confirmation, class: 'form-control bg-light', placeholder: User.human_attribute_name(:password_confirmation) %>
             </div>
+            <p class="font-mini-size pt-1">
+              本サービスに登録することで、ChariLogの<span><%= link_to t("defaults.terms"), '/terms', class: 'text-primary', style: "text-decoration:none;" %></span>、<span><%= link_to t("defaults.privacy_policy"), '/privacy_policy', class: 'text-primary', style: "text-decoration:none;" %></span>に同意するものとします。
+            </p>
             <div class="form-group">
               <%= f.submit t("defaults.register"), class: 'btn btn-primary btn-block font-weight-bold rounded-pill mt-4' %>
             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
     <div class="user-panel d-flex flex-column flex-md-row justify-content-center align-items-center">
       <div class="user-avatar d-flex flex-wrap align-items-center my-3">
         <%= link_to @user.avatar, "data-lightbox": @user.avatar do %>
-          <%= image_tag @user.avatar.variant(gravity: :center, resize: "120x120^!", crop:"120x120+0+0"), class: "img rounded-circle bg-dark-subtle me-4", style: "display: inline-block;" %>
+          <%= image_tag @user.avatar.variant(gravity: :center, resize: "120x120^!", crop:"120x120+0+0"), class: "img rounded-circle bg-dark-subtle me-4 me-lg-5", style: "display: inline-block;" %>
         <% end %>
         <div class="follow-btn mobile-size" style="display: inline-block;">
           <% if @user.id == current_user.id %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
     <div class="user-panel d-flex flex-column flex-md-row justify-content-center align-items-center">
       <div class="user-avatar d-flex flex-wrap align-items-center my-3">
         <%= link_to @user.avatar, "data-lightbox": @user.avatar do %>
-          <%= image_tag @user.avatar.variant(gravity: :center, resize: "120x120^!", crop:"120x120+0+0"), class: "img rounded-circle bg-dark-subtle me-4 me-lg-5", style: "display: inline-block;" %>
+          <%= image_tag @user.avatar.variant(gravity: :center, resize: "120x120^!", crop:"120x120+0+0"), class: "img rounded-circle bg-dark-subtle hover-opacity-75 me-4 me-lg-5", style: "display: inline-block;" %>
         <% end %>
         <div class="follow-btn mobile-size" style="display: inline-block;">
           <% if @user.id == current_user.id %>
@@ -30,7 +30,7 @@
             <% if @user.my_bike.present? %>
               <%= @user.my_bike %>
             <% else %>
-              <%= t(".no_mybike") %>
+              <%= t("defaults.no_mybike") %>
             <% end %>
           </div>
           <div class="post-count d-flex flex-wrap mb-2">
@@ -46,14 +46,14 @@
             </div>
           </div>
           <div class="element-count d-flex flex-wrap">
-            <%= link_to followers_user_path, style:"text-decoration:none;" do %>
+            <%= link_to followers_user_path, class:"hover-opacity-75", style:"text-decoration:none;" do %>
               <div class="text-secondary me-3">
                 <%= t(".follower") %>
                 <span>:</span>
                 <%= @user.followeds.count %>人
               </div>
             <% end %>
-            <%= link_to follows_user_path, style:"text-decoration:none;" do %>
+            <%= link_to follows_user_path, class:"hover-opacity-75", style:"text-decoration:none;" do %>
               <div class="text-secondary me-3">
                 <%= t(".follow") %>
                 <span>:</span>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -41,6 +41,7 @@ ja:
     select_bike: 'メーカーを選択'
     search_result: '検索結果'
     no_search_result: '検索結果がありません'
+    no_mybike: '未登録'
     message:
       require_login: 'ログインしてください'
       created: '%{item}を作成しました'
@@ -77,7 +78,6 @@ ja:
       mypage: 'マイページ'
       no_post: 'まだ投稿はありません'
       no_bio: '自己紹介は登録されていません'
-      no_mybike: '登録されていません'
       follow: 'フォロー'
       follower: 'フォロワー'
       post: '投稿数'

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -74,6 +74,7 @@ ja:
       fail: 'ユーザー登録に失敗しました'
     show:
       title: 'ユーザー詳細'
+      mypage: 'マイページ'
       no_post: 'まだ投稿はありません'
       no_bio: '自己紹介は登録されていません'
       no_mybike: '登録されていません'
@@ -130,10 +131,6 @@ ja:
     destroy:
       title:
   profiles:
-    show:
-      title: 'マイページ'
-      follow: 'フォロー中'
-      follower: 'フォロワー'
     edit:
       title: 'プロフィール編集'
   password_resets:


### PR DESCRIPTION
## 概要

* Userコントローラー内の重複しているコードをprivateに移して一本化
* users#showアクションのN+1問題の解消
* いいねマーク/カウントのデザイン調整
* ○日前の記述の位置調整
* ユーザーアイコン横の余白調整
* ユーザー詳細ページとマイページのタイトルを区別できるように条件分岐を実装
* ホバー時のエフェクトを追加
* プロフィール編集フォームの背景色を追加
* ユーザー一覧のMyBikeがない場合の文言を追加
* ユーザー登録時の注意書きを追加
