### PR TITLE
add: 自動ログイン機能の追加

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,7 +2,7 @@ class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[create]
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember])
     if @user
       redirect_back_or_to root_path, success: t(".success")
     else

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -11,10 +11,14 @@
       <div class="form-group">
         <%= f.text_field :email, class: 'form-control bg-light', placeholder: t("defaults.email"), autocomplete: 'email' %>
       </div>
-      <div class="form-group text-left pb-2">
+      <div class="form-group text-left font-mini-size">
         <%= f.password_field :password, class: 'form-control bg-light ', placeholder: t("defaults.password"), type: "password", id: "password"%>
         <input name="pwPrev" type="checkbox" onChange="document.getElementById('password').type = (this.checked) ? 'text' : 'password';">
         <%= t("defaults.look_password") %>
+        <div class="remember-me">
+          <%= check_box_tag :remember, params[:remember], false %>
+          <%= label_tag :remember, t("defaults.remember_me") %>
+        </div>
       </div>
       <div class="actions">
         <%= f.submit t("defaults.login"), class: 'form-control btn btn-primary font-weight-bold rounded-pill' %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -319,7 +319,7 @@ Rails.application.config.sorcery.configure do |config|
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
     #
-    # user.remember_me_for =
+    user.remember_me_for = 604800
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -25,6 +25,7 @@ ja:
     setting_profile: '登録情報設定'
     item_management: 'アイテム管理'
     back: '戻る'
+    remember_me: '次回から自動でログイン'
     to_top_page: 'トップページへ戻る'
     to_my_page: 'マイページへ戻る'
     to_register_page: '新規登録ページへ'

--- a/db/migrate/20240213111922_sorcery_remember_me.rb
+++ b/db/migrate/20240213111922_sorcery_remember_me.rb
@@ -1,0 +1,8 @@
+class SorceryRememberMe < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :remember_me_token, :string, default: nil
+    add_column :users, :remember_me_token_expires_at, :datetime, default: nil
+
+    add_index :users, :remember_me_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_31_065252) do
+ActiveRecord::Schema.define(version: 2024_02_13_111922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,10 @@ ActiveRecord::Schema.define(version: 2024_01_31_065252) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 


### PR DESCRIPTION
## 概要

* 自動ログイン機能を追加
* トップページ(ログインぺージ)内に次回から自動でログインというテキストをつけたチェックボックスを追加


## 確認方法

1. サイトにアクセスして、次回から自動でログインにチェックを入れてログイン
2. そのままブラウザを終了して再度サイトにアクセスすると自動でログインされた状態になるので確認して下さい


## 以下のissueに関するpull requestです

#76
