### PR TITLE
Fix: 余白調整・ログイン前のフッターに表示・非表示の条件分岐を追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,9 @@
         <%= render "/shared/flash_message" %>
         <%= yield %>
       </div>
-      <div class="before-login-footer-wrapper shadow mt-5">
+      <div class="before-login-footer-wrapper shadow mt-5
+                  <%= controller_name == 'password_resets' && action_name == 'new' ||
+                      controller_name == 'password_resets' && action_name == 'edit' ? 'd-none' : '' %>">
         <%= render "/shared/footer" %>
       </div>
     <% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -20,7 +20,7 @@
           <div class="form-group">
             <i class="fas fa-envelope"></i>
             <%= f.label User.human_attribute_name(:email), class: "fw-bold", for: "email" %>
-            <%= f.text_field :email, class: 'form-control bg-light', value: @user.email, placeholder: User.human_attribute_name(:email), id: "email" %>
+            <%= f.text_field :email, class: 'form-control bg-light', value: @user.email, placeholder: User.human_attribute_name(:email), id: "email", autocomplete: "email" %>
           </div>
           <div class="form-group">
             <i class="fas fa-lock"></i>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,8 @@
           <i class="fas fa-angle-left fa-2x text-dark mx-3"></i>
         <% end %>
       <% end %>
-      <h5 class="page-title d-lg-none fw-bold mx-auto my-2 <%= logged_in? ? '' : 'pe-5' %>">
+      <h5 class="page-title d-lg-none fw-bold mx-auto my-2 <%= logged_in? || controller_name == 'password_resets' && action_name == 'edit' ? '' : 'pe-5' %>
+                                                           <%= logged_in? && controller_name == 'password_resets' && action_name == 'edit' ? 'ps-5' : '' %>">
         <% if logged_in? %>
           <% unless current_page?(user_path(current_user)) %>
             <%= t("#{controller_name}.#{action_name}.title") %>


### PR DESCRIPTION
## 概要

* 余白調整
* ログイン前フッターに表示・非表示の条件分岐を追加

