### PR TITLE
Add: アイテム検索機能(楽天API)/各投稿にアイテム情報の紐付け

### DIFF
--- a/app/assets/javascripts/rakuten-search.js
+++ b/app/assets/javascripts/rakuten-search.js
@@ -1,0 +1,66 @@
+$(document).ready(function() {
+  // ”使用アイテムを登録する”ボタンをクリックしたときの処理
+  $(document).on('click', '#rakuten-link-button', function(e) {
+    e.preventDefault();
+
+    // モーダルの表示
+    $('#rakuten-modal').modal('show');
+  });
+});
+
+// モーダルウィンドウ内の"追加"ボタンがクリックされたときの処理
+$(document).on('click', '.rakuten-add-button', function(e) {
+  e.preventDefault();
+
+  // JSON形式のデータに変換
+  var jsonData = JSON.stringify({
+    item_code: $(this).data('code'),
+    name: $(this).data('item-name'),
+    price: $(this).data('price'),
+    image: $(this).data('image-url'),
+    rakuten_url: $(this).data('url')
+  });
+
+  // アイテムを4つまでフィールドに登録、表示
+  for (var i = 1; i <= 4; i++) {
+    var itemField = $("#post_items" + i);
+    if (itemField.val() === "") {
+      itemField.val(jsonData);
+      $('#rakuten_image' + i).attr('src', $(this).data('image-url')).toggleClass('d-none');
+      $('#rakuten_name_text' + i).text($(this).data('item-name'));
+      $('#rakuten_url_text' + i).text($(this).data('url')).toggleClass('text-center');
+      if (i !== 1) {
+        $('#rakuten_data_wrap' + i).addClass('border-top mt-3 pt-3');
+      }
+      break;
+    }
+  }
+  // クリアボタンの表示
+  $('#remove_rakuten_item_button').show();
+  // モーダルの非表示化
+  $('#rakuten-modal').modal('hide');
+});
+
+// 削除ボタンをクリックした時の処理
+$(document).on('click', '#remove_rakuten_item_button', function(e) {
+  e.preventDefault();
+
+  // プレビューを削除
+  for (var i = 1; i <= 4; i++) {
+    var urlTextElement = $('#rakuten_url_text' + i);
+    
+    $("#post_items" + i).val("");
+    $('#rakuten_image' + i).removeAttr('src').toggleClass('d-none');
+    $('#rakuten_name_text' + i).text('');
+    $('#rakuten_data_wrap' + i).removeClass('border-top mt-3 pt-3');
+    
+    if (i === 1) {
+      urlTextElement.text('登録アイテムはありません');
+    } else {
+      urlTextElement.text('');
+    }
+    urlTextElement.toggleClass('text-center');
+  }
+  // クリアボタンの非表示化
+  $(this).hide();
+});

--- a/app/assets/javascripts/rakuten-search.js
+++ b/app/assets/javascripts/rakuten-search.js
@@ -1,4 +1,7 @@
 $(document).ready(function() {
+  // 初期状態ではクリアボタンを非表示にする
+  $('#remove_rakuten_item_button').hide();
+
   // ”使用アイテムを登録する”ボタンをクリックしたときの処理
   $(document).on('click', '#rakuten-link-button', function(e) {
     e.preventDefault();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,17 @@ body {
   padding: 0 5px;
 }
 
+.already-add::after {
+  content: "登録済";
+  font-weight: lighter;
+  font-size: 13px;
+  border-radius: 2px;
+  color: white;
+  background-color: blue;
+  margin-left: 5px;
+  padding: 0 5px;
+}
+
 .operetion-bg {
   background-color: rgba(0, 0, 0, 0.7);
   border-radius: 50%;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -60,6 +60,18 @@ class PostsController < ApplicationController
     render json: @image_blob
   end
 
+  def search_rakuten
+    if params[:q].present?
+      @rakuten_items = RakutenWebService::Ichiba::Item.search({
+        keyword: params[:q],
+        hits: 15,
+      })
+    end
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def set_post

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,4 @@
+class Item < ApplicationRecord
+  has_many :post_items, dependent: :destroy
+  has_many :posts, through: :post_items
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,5 +5,8 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_users, through: :likes, source: :user
 
+  has_many :post_items, dependent: :destroy
+  has_many :items, through: :post_items
+
   validates :title, presence: true
 end

--- a/app/models/post_item.rb
+++ b/app/models/post_item.rb
@@ -1,0 +1,4 @@
+class PostItem < ApplicationRecord
+  belongs_to :post
+  belongs_to :item
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
             <%= render "/shared/main_content_cover_image_mobile" %>
            
             <!-- メインコンテンツ -->
-            <div class="content-wrapper col-xl-10 col-lg-10 col-md-12 bg-white px-4 px-sm-5 pt-4 z-0">
+            <div class="content-wrapper col-xl-10 col-lg-10 col-md-12 bg-white px-2 px-sm-5 pt-4 z-0">
               <%= render "/shared/flash_message" %>
 
               <!-- メインコンテンツカバー画像（PC以上） -->
@@ -45,6 +45,9 @@
               <%= yield %>
               <div class="mask-area overlay"></div>
             </div>
+
+            <!-- モーダル/楽天市場検索 -->
+            <%= render "/shared/rakuten_search_modal" %>
 
             <!-- フッターPC以上 -->
             <div class="footer-wrapper bg-light z-3 mt-4 d-sm-block d-none">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -56,15 +56,46 @@
           <%= f.label :content, class: "fw-bold", for: "content" %>
           <%= f.text_area :content, class: 'form-control', id: "content", rows: 5 %>
         </div>
+        <div class="form-group field mb-4">
+          <div class="label-container fw-bold", for: "post_rakuten_url">
+            <i class="fa-solid fa-link"></i>
+            アイテム登録
+          </div>
+          <div class="mt-3">
+            <%= link_to "使用アイテムを登録する", "#", id: "rakuten-link-button", local: true, class: "btn btn-success btn-outline-secondary" %><br>
+            <div class="row align-items-center">
+              <p class="my-4 col-8 col-sm-9"><選択されたアイテム></p>
+              <div class="col-2 d-flex justify-content-center">
+                <button class="btn btn-primary btn-outline-dark link-delete-btn" id="remove_rakuten_item_button">クリア</button>
+              </div>
+            </div>
+            <%= f.hidden_field 'items1', multiple: true %>
+            <%= f.hidden_field 'items2', multiple: true %>
+            <%= f.hidden_field 'items3', multiple: true %>
+            <%= f.hidden_field 'items4', multiple: true %>
+            
+            <% (1..4).each do |index| %>
+              <div class="row align-items-center justify-content-around" id="rakuten_data_wrap<%= index %>">
+                <img id="rakuten_image<%= index %>" class="col-3 d-flex d-none">
+                <p class="d-flex mb-0 text-secondary col-8" id="rakuten_name_text<%= index %>"></p>
+                <p class="text-center mb-0 text-secondary mt-2 font-mini-size col-12 px-4" id="rakuten_url_text<%= index %>">
+                  <%= '登録アイテムはありません' if index == 1 %>
+                </p>
+              </div>
+            <% end %>
+
+          </div>
+        </div>
         <div class='text-center'>
           <% if f.object.new_record? %>
-            <%= f.submit t("defaults.post"), class: 'btn btn-success m-4 submit-button' %>
+            <%= f.submit t("defaults.post"), class: 'btn btn-success m-3 px-3 px-sm-5 submit-button' %>
           <% else %>
-            <%= f.submit t("defaults.edit"), class: 'btn btn-primary m-4 submit-button' %>
+            <%= f.submit t("defaults.edit"), class: 'btn btn-primary m-3 px-3 px-sm-5 submit-button' %>
           <% end %>
-          <%= link_to t("defaults.to_posts_page"), posts_path, class: 'btn btn-info m-4' %>
+          <%= link_to t("defaults.to_posts_page"), posts_path, class: 'btn btn-info m-3 px-3 px-sm-5' %>
         </div>
       </div>
     <% end %>
   </div>
 </div>
+

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -57,33 +57,40 @@
           <%= f.text_area :content, class: 'form-control', id: "content", rows: 5 %>
         </div>
         <div class="form-group field mb-4">
-          <div class="label-container fw-bold", for: "post_rakuten_url">
-            <i class="fa-solid fa-link"></i>
-            アイテム登録
+          <div class="label-container fw-bold <%= @post.items.present? ? 'already-add' : '' %>", for: "post_rakuten_url">
+            <i class="fa-solid fa-tags"></i>
+            アイテム登録(最大4つまで)
           </div>
           <div class="mt-3">
-            <%= link_to "使用アイテムを登録する", "#", id: "rakuten-link-button", local: true, class: "btn btn-success btn-outline-secondary" %><br>
-            <div class="row align-items-center">
-              <p class="my-4 col-8 col-sm-9"><選択されたアイテム></p>
-              <div class="col-2 d-flex justify-content-center">
-                <button class="btn btn-primary btn-outline-dark link-delete-btn" id="remove_rakuten_item_button">クリア</button>
-              </div>
-            </div>
-            <%= f.hidden_field 'items1', multiple: true %>
-            <%= f.hidden_field 'items2', multiple: true %>
-            <%= f.hidden_field 'items3', multiple: true %>
-            <%= f.hidden_field 'items4', multiple: true %>
-            
-            <% (1..4).each do |index| %>
-              <div class="row align-items-center justify-content-around" id="rakuten_data_wrap<%= index %>">
-                <img id="rakuten_image<%= index %>" class="col-3 d-flex d-none">
-                <p class="d-flex mb-0 text-secondary col-8" id="rakuten_name_text<%= index %>"></p>
-                <p class="text-center mb-0 text-secondary mt-2 font-mini-size col-12 px-4" id="rakuten_url_text<%= index %>">
-                  <%= '登録アイテムはありません' if index == 1 %>
-                </p>
-              </div>
-            <% end %>
+            <% if @post.items.present? %>
 
+              <%= render 'item_list' %>
+
+            <% else %>
+
+              <%= link_to "使用アイテムを登録する", "#", id: "rakuten-link-button", local: true, class: "btn btn-success btn-outline-secondary" %><br>
+              <div class="row align-items-center">
+                <p class="my-4 col-8 col-sm-9"><選択されたアイテム></p>
+                <div class="col-2 d-flex justify-content-center">
+                  <button class="btn btn-primary btn-outline-dark link-delete-btn" id="remove_rakuten_item_button">クリア</button>
+                </div>
+              </div>
+              <%= f.hidden_field 'items1', multiple: true %>
+              <%= f.hidden_field 'items2', multiple: true %>
+              <%= f.hidden_field 'items3', multiple: true %>
+              <%= f.hidden_field 'items4', multiple: true %>
+              
+              <% (1..4).each do |index| %>
+                <div class="row align-items-center justify-content-around" id="rakuten_data_wrap<%= index %>">
+                  <img id="rakuten_image<%= index %>" class="col-3 d-flex d-none">
+                  <p class="d-flex mb-0 text-secondary font-mini-size col-8" id="rakuten_name_text<%= index %>"></p>
+                  <p class="text-center mb-0 text-secondary mt-2 font-mini-size col-12 px-4" id="rakuten_url_text<%= index %>">
+                    <%= '登録アイテムはありません' if index == 1 %>
+                  </p>
+                </div>
+              <% end %>
+
+            <% end %>
           </div>
         </div>
         <div class='text-center'>

--- a/app/views/posts/_item_list.html.erb
+++ b/app/views/posts/_item_list.html.erb
@@ -1,0 +1,17 @@
+<% @post.items.each_with_index do |item, index| %>
+  <div class="row align-items-center justify-content-around py-4 <%= index != 0 ? 'border-top' : '' %>">
+    <%= image_tag item.image, class: 'd-flex col-4 col-sm-3 col-xl-2' %>
+    <div class="item-info d-flex col-8 col-sm-9 col-xl-10 flex-column text-secondary">
+      <p class="font-mini-size"><%= item.name.truncate(80) %></p>
+      <p class="fw-bold text-decoration-underline"><%= "参考価格：#{item.price}円" %></p>
+    </div>
+    <div class="rakuten-url text-right">
+      <%= link_to item.rakuten_url, class: "btn btn-light border text-secondary me-2", target: "_blank", style:"text-decoration:none;", data: { confirm: '楽天で商品情報を確認しますか？' } do %>
+        <div class="font-mini-size">
+          <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          楽天商品ページへ
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -46,11 +46,21 @@
       <% end %>
 
       <div class="card-body hover-opacity-50 pt-3">
-        <div class="like-count d-flex align-items-center text-danger h4 mb-3">
-          <ion-icon name="heart-circle-outline"></ion-icon>
+        <div class="d-flex align-items-center h4 mb-3">
+
+          <!-- いいね数カウント -->
+          <i class="fa-solid fa-heart text-danger"></i>
           <div class="text-secondary ms-1">
             <div class="fs-5" id="likes-count-<%= post.id %>">
               <%= post.likes.count %>
+            </div>
+          </div>
+
+          <!-- アイテム数カウント -->
+          <i class="fa-solid fa-tags text-success ms-3"></i>
+          <div class="text-secondary ms-1">
+            <div class="fs-5" id="likes-count-<%= post.id %>">
+              <%= post.items.count %>
             </div>
           </div>
         </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,4 +1,5 @@
 <% set_meta_tags title: t('.title') %>
+<%= javascript_include_tag "rakuten-search.js" %>
 
 <div class="container-fluid p-0 mb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,5 @@
 <% set_meta_tags title: t('.title') %>
+<%= javascript_include_tag "rakuten-search.js" %>
 
 <div class="container pt-2 mb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">

--- a/app/views/posts/search_rakuten.js.erb
+++ b/app/views/posts/search_rakuten.js.erb
@@ -1,0 +1,7 @@
+$('#rakuten_result').empty();
+
+<% if @rakuten_items.present? %>
+  $('#rakuten_result').html('<%= escape_javascript(render partial: 'shared/search_rakuten', locals: { rakuten_items: @rakuten_items }) %>');
+<% else %>
+  $('#rakuten_result').html('<p class="text-center">条件に一致する検索結果はありません</p>');
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -21,8 +21,8 @@
           <%= link_to @post.user.name, user_path(@post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
         </div>
         <div class="operation_area d-flex align-items-center ml-auto">
-          <div class="like-count d-flex align-items-center text-danger fs-4">
-            <ion-icon name="heart-circle-outline"></ion-icon>
+          <div class="like-count d-flex align-items-center fs-4">
+            <i class="fa-solid fa-heart text-danger"></i>
             <div class="text-dark ms-1">
               <div class="fs-5" id="likes-count-<%= @post.id %>">
                 <%= @post.likes.count %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -73,12 +73,24 @@
           <% end %>
         </div>
       </div>
-      <h4 class="card-title fw-bold m-0"><%= @post.title %></h4>
-      <p class="card-text"><%= @post.content %></p>
-      <span class="text-secondary">
-        <i class="far fa-clock clock-icon me-1">
-        </i><%= time_ago_in_words(@post.created_at) %>前
-      </span>
+      <div class="d-flex align-items-end">
+        <h5 class="card-title fw-bold m-0"><%= @post.title %></h5>
+        <span class="text-secondary ms-2 font-mini-size">
+          <i class="far fa-clock clock-icon me-1">
+          </i><%= time_ago_in_words(@post.created_at) %>前
+        </span>
+      </div>
+      
+      <p class="card-text mt-2"><%= @post.content %></p>
+
+      <div class="mt-3">
+        <div>
+          <i class="fa-solid fa-tags"></i>
+          使用しているアイテム
+        </div>
+        <%= render 'item_list' %>
+      </div>
+
     </div>
   </div>
 </div>  

--- a/app/views/shared/_rakuten_search_modal.html.erb
+++ b/app/views/shared/_rakuten_search_modal.html.erb
@@ -1,0 +1,26 @@
+<div class="modal fade" id="rakuten-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="exampleModalLabel">楽天で商品を検索</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="my-4">
+        <%= form_with url: search_rakuten_posts_path, method: :get, local: false, class: "row" do |f| %>
+          <div class="offset-1 offset-sm-2 col-7">
+            <%= f.text_field :q, value: params[:q], class: "form-control", placeholder: "キーワードで検索" %>
+          </div>
+          <div class="col-1">
+            <%= f.submit "検索", class: "btn btn-dark text-light" %>
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-body pb-0" id="rakuten_result">
+        <%= render partial: 'shared/search_rakuten', locals: { rakuten_items: @rakuten_items } %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_search_rakuten.html.erb
+++ b/app/views/shared/_search_rakuten.html.erb
@@ -1,0 +1,29 @@
+<% if rakuten_items %>
+  <div class="mt-56">
+    <div class="row align-items-center justify-content-around bg-light border-bottom py-2 d-none d-lg-flex">
+      <div class="col-3 fw-bold text-center">商品画像</div>
+      <div class="col-5 fw-bold text-center">商品名</div>
+      <div class="col-2 fw-bold text-center">商品リンク</div>
+      <div class="col-2"></div>
+    </div>
+    <% if rakuten_items.count == 0 %>
+      <p class="text-center mt-4 mb-3">条件に一致する検索結果はありません</p>
+    <% else %>
+      <% rakuten_items.each do |rakuten_item| %>
+        <div class="row g-4 justify-content-around border-bottom py-4">
+          <div class="col-5 col-lg-3 d-flex align-items-center justify-content-center"><%= image_tag rakuten_item.medium_image_urls.first, alt: rakuten_item.name %></div>
+          <div class="col-7 col-lg-5 d-flex align-items-center justify-content-center"><%= rakuten_item.name %></div>
+          <div class="col-7 col-lg-2 d-flex align-items-center justify-content-center">
+            <%= link_to rakuten_item.url, class: "text-secondary", target: "_blank", style:"text-decoration:none;", data: { confirm: '楽天で商品情報を確認しますか？' } do %>
+              <i class="fa-solid fa-arrow-up-right-from-square"></i>
+              楽天商品ページへ
+            <% end %>
+          </div>
+          <div class="col-5 col-lg-2 d-flex align-items-center justify-content-center">
+            <%= link_to '選択', '#', data: { url: rakuten_item.url, image_url: rakuten_item.medium_image_urls.first, item_name: rakuten_item.name, price: rakuten_item.price, code: rakuten_item.code }, class: "btn btn-secondary btn-block text-light rakuten-add-button" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/static_pages/_post_list.html.erb
+++ b/app/views/static_pages/_post_list.html.erb
@@ -12,11 +12,21 @@
             <div class="user-name d-flex align-items-center text-break">
               <%= link_to post.user.name, user_path(post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
             </div>
-            <div class="like_count d-flex align-items-center ml-auto text-danger h4 mb-0">
-              <ion-icon name="heart-circle-outline"></ion-icon>
+            <div class="d-flex align-items-center ml-auto h4 mb-0">
+
+              <!-- いいね数カウント -->
+              <i class="fa-solid fa-heart text-danger"></i>
               <div class="text-secondary ms-1">
-                <div id="likes-count-<%= post.id %>">
+                <div class="fs-5" id="likes-count-<%= post.id %>">
                   <%= post.likes.count %>
+                </div>
+              </div>
+
+              <!-- アイテム数カウント -->
+              <i class="fa-solid fa-tags text-success ms-2"></i>
+              <div class="text-secondary ms-1">
+                <div class="fs-5" id="likes-count-<%= post.id %>">
+                  <%= post.items.count %>
                 </div>
               </div>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   resources :posts do
     resource :like, only: %i[create destroy]
     get 'likes', on: :collection
+    get 'search_rakuten', on: :collection
     post 'upload_image', on: :collection
   end
 

--- a/db/migrate/20240215091449_create_items.rb
+++ b/db/migrate/20240215091449_create_items.rb
@@ -1,0 +1,13 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.string :name
+      t.integer :price
+      t.string :rakuten_url
+      t.string :image
+      t.string :item_code, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240215091902_create_post_items.rb
+++ b/db/migrate/20240215091902_create_post_items.rb
@@ -1,0 +1,11 @@
+class CreatePostItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :post_items do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_items, [:post_id, :item_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_13_111922) do
+ActiveRecord::Schema.define(version: 2024_02_15_091902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,16 @@ ActiveRecord::Schema.define(version: 2024_02_13_111922) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "items", force: :cascade do |t|
+    t.string "name"
+    t.integer "price"
+    t.string "rakuten_url"
+    t.string "image"
+    t.string "item_code", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -44,6 +54,16 @@ ActiveRecord::Schema.define(version: 2024_02_13_111922) do
     t.index ["post_id"], name: "index_likes_on_post_id"
     t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "post_items", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_post_items_on_item_id"
+    t.index ["post_id", "item_id"], name: "index_post_items_on_post_id_and_item_id", unique: true
+    t.index ["post_id"], name: "index_post_items_on_post_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -85,5 +105,7 @@ ActiveRecord::Schema.define(version: 2024_02_13_111922) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "post_items", "items"
+  add_foreign_key "post_items", "posts"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :item do
+    name { "MyString" }
+    price { 1 }
+    rakuten_url { "MyString" }
+    image { "MyString" }
+    item_code { "MyString" }
+  end
+end

--- a/spec/factories/post_items.rb
+++ b/spec/factories/post_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post_item do
+    post { nil }
+    item { nil }
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_item_spec.rb
+++ b/spec/models/post_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PostItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

* 楽天APIを使用したアイテム検索機能の実装
* アイテム選択時のプレビュー表示実装
* 各投稿とアイテム情報の紐付けができるようコントローラーでメソッドを構築
* ビューファイルで表示対応(show, editなど)


## 確認方法

1. ログイン後、投稿作成画面に遷移して下さい
2. 必須の項目と任意の項目を入力後、「使用アイテムを登録する」ボタンを押して下さい
3. モーダルが表示されるので、モーダル内の検索バーに商品名を入力して検索ボタンを押して下さい。
4. 検索結果が表示されるので投稿に紐付けたいアイテムを選択して下さい。
5. 投稿後、投稿の詳細ページ・編集ページに遷移して下さい。
6. それぞれのページで商品画像・商品名・商品価格・楽天へのリンクがあるので確認して下さい。


## 以下のissueに関するpull requestです

#24 #53
