### PR TITLE
Add: アバター画像選択のバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: { case_sensitive: true }
   validates :name, presence: true
   validates :bio, length: { maximum: 160 }
+  validate :avatar_size
 
   enum my_bike:{
     ANCHOR（アンカー）:0,ARAYA（アラヤ）:1,ARGON（アルゴン）:2,AVEDIO（エヴァディオ）:3,BASSO（バッソ）:4,BH（ビーエイチ）:5,Bianchi（ビアンキ）:6,BMC（ビーエムシー）:7,BOMA（ボーマ）:8,BOTTECCHIA（ボッテキア）:9,BRIDGESTONE（ブリヂストン）:10,BROMPTON（ブロンプトン）:11,
@@ -37,6 +38,12 @@ class User < ApplicationRecord
     if !self.avatar.attached?
       self.avatar.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'sample.png')),
                          filename: 'sample.png', content_type: 'image/png')
+    end
+  end
+
+  def avatar_size
+    if avatar.present? && (avatar.blob.byte_size > 5.megabytes)
+      errors.add(:avatar, 'はサイズ5MB以内の画像にしてください')
     end
   end
 


### PR DESCRIPTION
## 概要

* アバター画像選択のバリデーションを設定


## 確認方法

1. ユーザー登録画面へ遷移して下さい。
2. 画像サイズ5MB以上の画像を選択して登録ボタンを押して下さい。
3. バリデーションエラーが発生するので確認して下さい。
