### PR TITLE
Fix&Update: 画像/テキストのレイアウト調整・ユーザー詳細内の投稿に並べ替え機能実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -31,3 +31,9 @@
 .delete-preview.open {
   display: block;
 }
+
+.avatar-panel .prev-img img {
+  object-fit: cover;
+  object-position: center center;
+  border-radius: 50%;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,11 @@ module ApplicationHelper
     'active' if current_page?(path)
   end
 
+  def sort_active_class(option)
+    current_order = params[:order]
+    return 'active' if current_order == option
+  end
+
   def search_from?
     params[:q].present?
   end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex align-items-center ps-0">
       <div class="user-avatar mx-2">
         <%= link_to user_path(current_user) do %>
-          <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
+          <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
         <% end %>
       </div>
       <div class="name_field text-break">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,7 +5,7 @@
         <div class="user-panel d-flex align-items-center py-2">
           <div class="user-avatar me-2">
             <%= link_to user_path(post.user) do %>
-              <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
+              <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
             <% end %>
           </div>
           <div class="user-name d-flex align-items-center text-break">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12 col-md-6 col-xl-4 mb-3">
   <div class="card shadow-sm">
-    <div class="header-area">
+    <div class="header-area <%= controller_name == 'users' && action_name == 'show' ? 'd-none' : '' %>">
       <div class="container">
         <div class="user-panel d-flex align-items-center py-2">
           <div class="user-avatar me-2">
@@ -28,7 +28,9 @@
           <div id="img-carousel" class="carousel slide" data-ride="carousel">
             <ol class="carousel-indicators">
               <% post.images.each_with_index do |image, index| %>
-                <li data-target="#img-carousel" data-slide-to="<%= index %>" class="<%= index == 0 ? 'active' : '' %>" style="<%= post.images.length == 1 ? 'display: none;' : 'cursor: default;' %>"></li>
+                <li data-target="#img-carousel" data-slide-to="<%= index %>"
+                    class="<%= index == 0 ? 'active' : '' %>"
+                    style="<%= post.images.length == 1 ? 'display: none;' : 'cursor: default;' %>"></li>
               <% end %>
             </ol>
 
@@ -42,7 +44,8 @@
           </div>
         </div>
       <% else %>
-        <%= image_tag "no_image.png", class: "d-block mx-auto img-fluid hover-opacity-75 border-top border-bottom", style: "height: auto; width: auto;" %>
+        <%= image_tag "no_image.png", class: "d-block mx-auto img-fluid hover-opacity-75 border-bottom #{controller_name == 'users' && action_name == 'show' ? '' : 'border-top'}",
+                                      style: "height: auto; width: auto;" %>
       <% end %>
 
       <div class="card-body hover-opacity-50 pt-3">

--- a/app/views/posts/_sort_posts_menu.html.erb
+++ b/app/views/posts/_sort_posts_menu.html.erb
@@ -15,6 +15,12 @@
       <li><%= link_to "タイトル(降順)", likes_posts_path(order: 'title_desc'), class: "dropdown-item text-dark #{sort_active_class('title_desc')}" %></li>
       <li><%= link_to "タイトル(昇順)", likes_posts_path(order: 'title_asc'), class: "dropdown-item text-dark #{sort_active_class('title_asc')}" %></li>
       <li><%= link_to "人気順", likes_posts_path(order: 'like_desc'), class: "dropdown-item text-dark #{sort_active_class('like_desc')}" %></li>
+    <% elsif current_page?(user_path(@user)) %>
+      <li><%= link_to "新着順", user_path(@user, order: 'new'), class: "dropdown-item text-dark #{sort_active_class('new')}" %></li>
+      <li><%= link_to "古い順", user_path(@user, order: 'old'), class: "dropdown-item text-dark #{sort_active_class('old')}" %></li>
+      <li><%= link_to "タイトル(降順)", user_path(@user, order: 'title_desc'), class: "dropdown-item text-dark #{sort_active_class('title_desc')}" %></li>
+      <li><%= link_to "タイトル(昇順)", user_path(@user, order: 'title_asc'), class: "dropdown-item text-dark #{sort_active_class('title_asc')}" %></li>
+      <li><%= link_to "人気順", user_path(@user, order: 'like_desc'), class: "dropdown-item text-dark #{sort_active_class('like_desc')}" %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/posts/_sort_posts_menu.html.erb
+++ b/app/views/posts/_sort_posts_menu.html.erb
@@ -1,20 +1,20 @@
 <div class="btn-group dropdown ms-auto border">
-  <button class="btn btn-lg dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+  <button class="btn btn-lg dropdown-toggle fw-bold" style="font-size: smaller;" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
     並び替え
   </button>
   <ul class="dropdown-menu dropdown-menu-end" id="dropdown_menu" aria-labelledby="dropdownMenuButton1">
     <% if current_page?(posts_path) %>
-      <li><%= link_to "新着順", posts_path(order: 'new'), class: "active dropdown-item text-dark" %></li>
-      <li><%= link_to "古い順", posts_path(order: 'old'), class: "dropdown-item text-dark" %></li>
-      <li><%= link_to "タイトル(降順)", posts_path(order: 'title_desc'), class: "dropdown-item text-dark" %></li>
-      <li><%= link_to "タイトル(昇順)", posts_path(order: 'title_asc'), class: "dropdown-item text-dark" %></li>
-      <li><%= link_to "人気順", posts_path(order: 'like_desc'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "新着順", posts_path(order: 'new'), class: "dropdown-item text-dark #{sort_active_class('new')}" %></li>
+      <li><%= link_to "古い順", posts_path(order: 'old'), class: "dropdown-item text-dark #{sort_active_class('old')}" %></li>
+      <li><%= link_to "タイトル(降順)", posts_path(order: 'title_desc'), class: "dropdown-item text-dark #{sort_active_class('title_desc')}" %></li>
+      <li><%= link_to "タイトル(昇順)", posts_path(order: 'title_asc'), class: "dropdown-item text-dark #{sort_active_class('title_asc')}" %></li>
+      <li><%= link_to "人気順", posts_path(order: 'like_desc'), class: "dropdown-item text-dark #{sort_active_class('like_desc')}" %></li>
     <% elsif current_page?(likes_posts_path) %>
-      <li><%= link_to "新着順", likes_posts_path(order: 'new'), class: "active dropdown-item text-dark" %></li>
-      <li><%= link_to "古い順", likes_posts_path(order: 'old'), class: "dropdown-item text-dark" %></li>
-      <li><%= link_to "タイトル(降順)", likes_posts_path(order: 'title_desc'), class: "dropdown-item text-dark" %></li>
-      <li><%= link_to "タイトル(昇順)", likes_posts_path(order: 'title_asc'), class: "dropdown-item text-dark" %></li>
-      <li><%= link_to "人気順", likes_posts_path(order: 'like_desc'), class: "dropdown-item text-dark" %></li>
+      <li><%= link_to "新着順", likes_posts_path(order: 'new'), class: "dropdown-item text-dark #{sort_active_class('new')}" %></li>
+      <li><%= link_to "古い順", likes_posts_path(order: 'old'), class: "dropdown-item text-dark #{sort_active_class('old')}" %></li>
+      <li><%= link_to "タイトル(降順)", likes_posts_path(order: 'title_desc'), class: "dropdown-item text-dark #{sort_active_class('title_desc')}" %></li>
+      <li><%= link_to "タイトル(昇順)", likes_posts_path(order: 'title_asc'), class: "dropdown-item text-dark #{sort_active_class('title_asc')}" %></li>
+      <li><%= link_to "人気順", likes_posts_path(order: 'like_desc'), class: "dropdown-item text-dark #{sort_active_class('like_desc')}" %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,7 +14,7 @@
       <div class="d-flex align-items-center">
         <div class="user-avatar me-2 sm-mx-2">
           <%= link_to user_path(@post.user) do %>
-            <%= image_tag @post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+            <%= image_tag @post.user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
           <% end %>
         </div>
         <div class="user-name d-flex align-items-center text-break">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -35,7 +35,7 @@
       <div class="user-panel d-lg-flex d-none align-items-center">
         <div class="user-avatar mx-2">
           <%= link_to user_path(current_user) do %>
-            <%= image_tag current_user.avatar.variant(gravity: :center, resize: "40x40^!", crop:"40x40+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
+            <%= image_tag current_user.avatar.variant(gravity: :center, resize: "40x40^", crop:"40x40+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
           <% end %>
         </div>
         <div class="user-name">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -5,7 +5,7 @@
         <div class="user-panel d-flex align-items-center mb-2">
           <div class="user-avatar me-2">
             <%= link_to user_path(current_user) do %>
-              <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
+              <%= image_tag current_user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
             <% end %>
           </div>
           <div class="user-name">

--- a/app/views/static_pages/_post_list.html.erb
+++ b/app/views/static_pages/_post_list.html.erb
@@ -6,7 +6,7 @@
           <div class="user-panel d-flex align-items-center py-2">
             <div class="user-avatar me-2">
               <%= link_to user_path(post.user) do %>
-                <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
+                <%= image_tag post.user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle", style: "display: inline-block;" %>
               <% end %>
             </div>
             <div class="user-name d-flex align-items-center text-break">

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <th class="text-center">
     <%= link_to user_path(user) do %>
-      <%= image_tag user.avatar.variant(gravity: :center, resize: "50x50^!", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
+      <%= image_tag user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0"), class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
     <% end %>
   </th>
   <th class="align-middle">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -17,7 +17,7 @@
             <%= render 'shared/error_messages', object: f.object %>
             <div class="form-group avatar-panel d-flex justify-content-center align-items-center flex-wrap pb-2">
               <div class="prev-img position-relative border-right border-secondary pe-3">
-                <%= image_tag 'sample.png', class: "d-block rounded-circle bg-dark-subtle", id: "prev_img" %>
+                <%= image_tag 'sample.png', class: "d-block bg-dark-subtle", id: "prev_img", style: "object-fit: cover;" %>
                 <div class="delete-preview">
                   <i class="fas fa-times fa-lg text-white rounded-circle bg-dark opacity-75 py-1 px-2"></i>
                 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -74,6 +74,12 @@
     </div>
   </div>
 
+  <div class="title-area d-flex flex-wrap align-items-center justify-content-center under-line my-2">
+    <h5 class="fw-bold text-decoration-underline m-0"><%= t(".post_index", user: @user.name) %></h5>
+    <!-- 並び替えリスト -->
+    <%= render 'posts/sort_posts_menu' %>
+  </div>
+
   <div class="row mb-sm-5">
     <% if @posts.present? %>
       <%= render @posts %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
     <div class="user-panel d-flex flex-column flex-md-row justify-content-center align-items-center p-0">
       <div class="user-avatar d-flex flex-wrap align-items-center mx-auto mx-md-0 my-3">
         <%= link_to @user.avatar, "data-lightbox": @user.avatar do %>
-          <%= image_tag @user.avatar.variant(gravity: :center, resize: "120x120^!", crop:"120x120+0+0"), class: "img rounded-circle bg-dark-subtle hover-opacity-75 me-5 me-md-4 me-lg-5", style: "display: inline-block;" %>
+          <%= image_tag @user.avatar.variant(gravity: :center, resize: "120x120^", crop:"120x120+0+0"), class: "img rounded-circle bg-dark-subtle hover-opacity-75 me-5 me-md-4 me-lg-5", style: "display: inline-block;" %>
         <% end %>
         <div class="follow-btn mobile-size" style="display: inline-block;">
           <%= render 'user_show_operation' %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -92,6 +92,7 @@ ja:
       post: '投稿数'
       all_likes: 'いいね数'
       leave_log!: 'あなたのログを残そう！'
+      post_index: '%{user}さんの投稿ログ'
     followers:
       title:  'フォロワー'
       no_followers: 'フォロワーはまだいません'


### PR DESCRIPTION
## 概要

* 並べ替えボタンのフォントサイズ縮小化
* 並べ替え実行時に選択した要素のクラスにactiveを付与するようヘルパー内にメソッドを構築
* 表示画像のアスペクト比を保つように修正
* ユーザー詳細ページ内の各投稿のヘッダーを非表示化
* ユーザー詳細内の各ユーザーの投稿一覧に並べ替え機能を実装