### PR TITLE
Fix: 間違った条件分岐を記述していたため修正

### DIFF
--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -2,7 +2,7 @@ RakutenWebService.configure do |c|
   if Rails.env.development?
     c.application_id = ENV['RWS_APPLICATION_ID_DEV']
     c.affiliate_id = ENV['RWS_AFFILIATION_ID_DEV']
-  elsif Rails.env.production?
+  else
     c.application_id = ENV['RWS_APPLICATION_ID_PROD']
     c.affiliate_id = ENV['RWS_AFFILIATION_ID_PROD']
   end


### PR DESCRIPTION
## 概要

* 本番環境用の環境変数は.envではなくherokuにて設定しているため、間違った条件分岐を変更