### PR TITLE
Fix: 画像データsample.pngの取り扱い方の見直し・アイコン削除メッセージの追加

### DIFF
--- a/app/controllers/profile/attachments_controller.rb
+++ b/app/controllers/profile/attachments_controller.rb
@@ -1,11 +1,16 @@
 class Profile::AttachmentsController < ApplicationController
   def destroy
-    avatar = ActiveStorage::Attachment.find(params[:id])
-    user = avatar.record
-    avatar.purge
+    user = User.find(params[:id])
+    user.avatar.purge
 
-    sample_avatar_path = Rails.root.join('app', 'assets', 'images', 'sample.png')
-    user.avatar.attach(io: File.open(sample_avatar_path), filename: 'sample.png')
+    sample_avatar = ActiveStorage::Blob.find_by(filename: 'sample.png')
+
+    if sample_avatar
+      user.avatar.attach(sample_avatar)
+    else
+      sample_avatar_path = Rails.root.join('app', 'assets', 'images', 'sample.png')
+      user.avatar.attach(io: File.open(sample_avatar_path), filename: 'sample.png')
+    end
 
     redirect_to edit_profile_path
   end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -17,7 +17,8 @@
                 <i class="fas fa-times text-white d-flex justify-content-center align-items-center h-100 m-0"></i>
               </div>
               <% if @user.avatar.attached? && @user.avatar.blob.filename.to_s != 'sample.png' %>
-                <%= link_to t("defaults.delete"), profile_attachment_path(@user.avatar.id), method: :delete, class: 'btn btn-danger d-block me-3 me-sm-4 mt-1 p-0' %>
+                <%= link_to t("defaults.delete"), profile_attachment_path(@user), method: :delete, class: 'btn btn-danger d-block me-3 me-sm-4 mt-1 p-0',
+                                                                                  data: {confirm: t('defaults.message.delete_confirm', item: User.human_attribute_name(:avatar))} %>
               <% end %>
             </div>
             <%= f.label :avatar, class: "m-0" do %>


### PR DESCRIPTION
## 概要

* sample.pngがDB内にあればそれが再利用されるようにコントローラーで設定
* アイコンの削除時に確認メッセージが表示されるように追加