### PR TITLE
Fix: レイアウト調整対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -73,6 +73,10 @@ body {
   font-size: 13px;
 }
 
+.pagination {
+  justify-content: center;
+}
+
 .over-line {
   &.border-1 {
     border-top: 1px solid;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
   private
 
   def load_users
-    @users = @q.result(distinct: true).with_attached_avatar.order(created_at: :desc).page(params[:page]).per(15)
+    @users = @q.result(distinct: true).with_attached_avatar.order(created_at: :desc).page(params[:page]).per(10)
     @user_count = @users.total_count
   end
 

--- a/app/helpers/footer_nav_link_helper.rb
+++ b/app/helpers/footer_nav_link_helper.rb
@@ -3,7 +3,7 @@ module FooterNavLinkHelper
     content_tag(:div, class: 'col-2 p-0 text-center') do
       link_to path, style: 'text-decoration:none;' do
         content_tag(:div, class: 'text-white') do
-          content_tag(:div, class: 'h5 m-0') {
+          content_tag(:div, class: 'h4 m-0') {
             tag.ion_icon(name: icon_name)
           } +
           content_tag(:div, title, class: 'title font-mini-size')

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container mb-sm-5">
+<div class="container mb-sm-5 pb-sm-5">
   <div class="row justify-content-center">
     <div class="col-xl-8 col-lg-9 col-md-10 col-12">     
       <div class="title-area text-center d-lg-block d-none mt-4 mb-5">

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags title: t('.title') %>
 <%= javascript_include_tag "rakuten-search.js" %>
 
-<div class="container-fluid p-0 mb-sm-5">
+<div class="container-fluid p-0 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title'), og: { title: t('.og_title') } %>
 
-<div class="container p-2">
+<div class="container p-2 mb-sm-5 pb-sm-5">
   <div class="title-area d-flex flex-wrap align-items-center justify-content-center under-line border-4 my-2">
     <h4 class="fw-bold m-0"><%= t(".post_index") %></h4>
     <!-- 並び替えリスト -->
@@ -34,7 +34,7 @@
     <% end %>
   </div>
 
-  <div class="row">
+  <div class="row text-center">
     <%= paginate @posts, theme: 'twitter-bootstrap-4' %>
   </div>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <!-- 掲示板一覧 -->
-  <div class="row mb-sm-5">
+  <div class="row mb-sm-4">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
@@ -34,7 +34,7 @@
     <% end %>
   </div>
 
-  <div class="row text-center">
+  <div class="row mt-3">
     <%= paginate @posts, theme: 'twitter-bootstrap-4' %>
   </div>
 

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container p-2">
+<div class="container p-2 mb-sm-5 pb-sm-5">
   <div class="title-area d-flex flex-wrap align-items-center justify-content-center under-line border-4 my-2">
     <%= link_to 'javascript:history.back()', class: "d-lg-flex d-none" do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -23,7 +23,7 @@
   <% end %>
 
   <!-- 掲示板一覧 -->
-  <div class="row mb-sm-5">
+  <div class="row mb-sm-4">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
@@ -38,7 +38,7 @@
     <% end %>
   </div>
 
-  <div class="row">
+  <div class="row mt-3">
     <%= paginate @posts, theme: 'twitter-bootstrap-4' %>
   </div>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags title: t('.title') %>
 <%= javascript_include_tag "rakuten-search.js" %>
 
-<div class="container pt-2 mb-sm-5">
+<div class="container pt-2 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,7 @@
 <% image_url = url_for(@post.images.first) %>
 <% set_meta_tags title: t('.title'), og: { title: t('.og_title', user: @post.user.name, date: l(@post.created_at, format: :short)) } %>
 
-<div class='container pt-2 mb-sm-5'>
+<div class='container pt-2 mb-sm-5 pb-sm-5'>
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,7 +1,7 @@
 <%= javascript_include_tag "avatar-prev.js" %>
 <% set_meta_tags title: t('.title') %>
 
-<div class="container my-sm-4">
+<div class="container my-sm-4 pb-sm-5">
   <div class="row justify-content-center">
     <div class="col-lg-8 col-md-9 col-11 p-0">
       <div class="text-left">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,12 +1,14 @@
 <footer class='footer py-3'>
   <div class='container'>
     <div class='row'>
-      <div class='col-md-12 text-center'>
-        <br>
+      <div class='col-md-12 text-center text-secondary'>
+        <div class="fw-bold fs-3 mb-2">~ INFORMATION ~</div>
         <%= link_to t("defaults.terms"), '/terms', class: 'text-secondary m-2', style: "text-decoration:none;" %>
+        <span><%= " / " %></span>
         <%= link_to t("defaults.privacy_policy"), '/privacy_policy', class: 'text-secondary text-nowrap m-2', style: "text-decoration:none;" %>
+        <span><%= " / " %></span>
         <%= link_to t("defaults.inquiry"), 'https://docs.google.com/forms/d/e/1FAIpQLSeHZcjha6HuQH0mcEN8ZAkv8ZMQY2p7YJCNxAFFcl1zUN_wkQ/viewform', class: "text-secondary text-nowrap m-2", style: "text-decoration:none;" %>
-        <p class='text-secondary mt-2'>© 2024. ChariLog.</p>
+        <p class='text-secondary mt-4'>© 2024 ChariLog. Copyright All Rights Reserved.</p>
       </div>
     </div>
   </div>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags title: t('.title') %>
 
 <main>
-  <div class="container mb-sm-5">
+  <div class="container mb-sm-5 pb-sm-5">
     <section class="section">
       <div class="content">
         <h2 class="text-center fw-bold d-lg-block d-none my-4">プライバシーポリシー</h2>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags title: t('.title') %>
 
 <main>
-  <div class="container mb-sm-5">
+  <div class="container mb-sm-5 pb-sm-5">
     <section class="section">
       <div class="content">
         <h2 class="text-center fw-bold d-lg-block d-none my-4">利用規約</h2>

--- a/app/views/users/_follow_btn.html.erb
+++ b/app/views/users/_follow_btn.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.following?(@user) %>
-  <%= link_to t("defaults.unfollow"), user_relationships_path(@user.id), method: :delete, class: "btn btn-danger fw-bold p-3 px-lg-4 px-xl-5" %>
+  <%= link_to t("defaults.unfollow"), user_relationships_path(@user.id), method: :delete, class: "btn btn-info fw-bold py-3 px-4 px-lg-4 px-xl-5", data: {confirm: 'フォローを解除しますか？'} %>
 <% else %>
-  <%= link_to t("defaults.follow"), user_relationships_path(@user.id), method: :post, class: "btn btn-primary fw-bold p-3 px-lg-4 px-xl-5" %>
+  <%= link_to t("defaults.follow"), user_relationships_path(@user.id), method: :post, class: "btn btn-outline-info fw-bold p-3 px-lg-4 px-xl-5" %>
 <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,11 +1,28 @@
 <tr>
-  <th class="text-center">
+  <th class="text-center py-4">
     <%= link_to user_path(user) do %>
-      <%= image_tag user.avatar.variant(gravity: :center, resize: "50x50^", crop:"50x50+0+0").processed, class: "rounded-circle bg-dark-subtle hover-opacity-75", style: "display: inline-block;" %>
+      <%= image_tag user.avatar.variant(gravity: :center, resize: "75x75^", crop:"75x75+0+0").processed,
+                    class: "rounded-circle bg-dark-subtle hover-opacity-75",
+                    style: "display: inline-block;" %>
     <% end %>
   </th>
   <th class="align-middle">
-    <%= link_to user.name, user_path(user), class: "user-name text-nowrap text-dark hover-opacity-50", style: "text-decoration:none;" %>
+    <div>
+      <%= link_to user.name, user_path(user), class: "user-name text-nowrap text-dark hover-opacity-50",
+                                              style: "text-decoration:none;" %>
+    </div>
+    <div class="font-mini-size text-nowrap mt-2">
+      <%= t("users.show.follower") %>
+      <%= user.followeds.count %>人
+      <span class="mx-1"><%= "/" %></span>
+      <%= t("users.show.follow") %>
+      <%= user.followers.count %>人
+    </div>
+    <div class="font-mini-size text-secondary text-nowrap mt-1">
+      <% if user.bio.present? %>
+        <%= user.bio.truncate(16) %>
+      <% end %>
+    </div>
   </th>
   <th class="align-middle">
     <% if user.my_bike.present? %>
@@ -17,9 +34,9 @@
   <th class="align-middle">
     <% if current_user != user %>
       <% if current_user.following?(user) %>
-        <%= link_to t("defaults.unfollow"), user_relationships_path(user.id), method: :delete, class: "btn btn-danger fw-bold" %>
+        <%= link_to t("defaults.unfollow"), user_relationships_path(user.id), method: :delete, class: "btn btn-info fw-bold py-3 px-4", data: {confirm: 'フォローを解除しますか？'} %>
       <% else %>
-        <%= link_to t("defaults.follow"), user_relationships_path(user.id), method: :post, class: "btn btn-primary fw-bold" %>
+        <%= link_to t("defaults.follow"), user_relationships_path(user.id), method: :post, class: "btn btn-outline-info fw-bold p-3" %>
       <% end %>
     <% end %>
   </th>

--- a/app/views/users/_user_table.html.erb
+++ b/app/views/users/_user_table.html.erb
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <th></th>
-        <th class="text-nowrap"><%= User.human_attribute_name(:name) %></th>
+        <th class="text-nowrap"><%= 'ユーザー情報' %></th>
         <th><%= User.human_attribute_name(:my_bike) %></th>
         <th></th>
       </tr>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container mb-5 mb-sm-5 pb-sm-5">
+<div class="container pt-2 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>
@@ -35,6 +35,10 @@
         <% end %>
       <% end %>
     <% end %>
+  </div>
+
+  <div class="row mt-3">
+    <%= paginate @users, theme: 'twitter-bootstrap-4' %>
   </div>
 
 </div>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container mb-5">
+<div class="container mb-5 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/users/follows.html.erb
+++ b/app/views/users/follows.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container mb-5 mb-sm-5 pb-sm-5">
+<div class="container pt-2 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>
@@ -35,6 +35,10 @@
         <% end %>
       <% end %>
     <% end %>
+  </div>
+
+  <div class="row mt-3">
+    <%= paginate @users, theme: 'twitter-bootstrap-4' %>
   </div>
 
 </div>

--- a/app/views/users/follows.html.erb
+++ b/app/views/users/follows.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container mb-5">
+<div class="container mb-5 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,6 @@
 <% set_meta_tags title: t('.title') %>
 
-<div class="container pt-2 mb-sm-5">
+<div class="container pt-2 mb-sm-5 pb-sm-5">
   <div class="title-area under-line border-4 d-lg-flex d-none my-2">
     <%= link_to 'javascript:history.back()' do %>
       <i class="fas fa-angle-left fa-2x me-4"></i>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,7 +35,7 @@
     <% end %>
   </div>
 
-  <div class="row">
+  <div class="row mt-3">
     <%= paginate @users, theme: 'twitter-bootstrap-4' %>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -80,7 +80,7 @@
     <%= render 'posts/sort_posts_menu' %>
   </div>
 
-  <div class="row mb-sm-5">
+  <div class="row mb-sm-4">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>
@@ -93,7 +93,7 @@
     <% end %>
   </div>
 
-  <div class="row">
+  <div class="row mt-3">
     <%= paginate @posts, theme: 'twitter-bootstrap-4' %>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <%= javascript_include_tag "user-show.js" %>
 <% set_meta_tags title: current_page?(user_path(current_user)) ? t('.mypage') : t('.title'), og: { title: t('.og_title', user: @user.name) } %>
 
-<div class="container px-md-4">
+<div class="container px-md-4 mb-sm-5 pb-sm-5">
   <div class="row pb-2 mb-4 border-bottom">
     <div class="user-panel d-flex flex-column flex-md-row justify-content-center justify-content-sm-around align-items-center p-0">
       <div class="user-avatar d-flex flex-wrap justify-content-center align-items-center mx-auto mx-md-0 my-3">

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 24
+  config.default_per_page = 18
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -22,7 +22,7 @@ ja:
     submit: '送信する'
     update: '更新する'
     follow: 'フォローする'
-    unfollow: 'フォロー解除'
+    unfollow: 'フォロー中'
     setting_profile: '登録情報設定'
     item_management: 'アイテム管理'
     back: '戻る'


### PR DESCRIPTION
## 概要

* フッター内にテキスト追加/修正
* ページネーションの配置を中央に変更
* ナビゲーションフッターのアイコン(記号)を拡大
* フォロー/フォロー解除ボタンの配色変更
* ユーザー一覧ページ内にフォロワー/フォロー数 & 自己紹介文を追加
* 上記複数のレイアウト調整対応に伴う余白調整