### PR TITLE
Update&Fix: 機能修正/レイアウト調整

### DIFF
--- a/app/assets/javascripts/avatar-prev.js.erb
+++ b/app/assets/javascripts/avatar-prev.js.erb
@@ -4,8 +4,11 @@ document.addEventListener('DOMContentLoaded', function() {
   const DeleteBtn = document.querySelector('.fa-times');
   const AvatarInput = document.querySelector('#user_avatar');
   const AvatarInputArea = document.querySelector('.input-area');
+  const UpdateBtn = document.querySelector('#profile_update_btn');
   const sampleImagePath = '<%= asset_path('sample.png') %>';
   const avatarUrl = document.querySelector('#prev_img').dataset.avatarUrl;
+  const nameField = document.querySelector('input[id="name_field"]');
+  const nameLabel = document.querySelector("label[for='name_field']");
   
   // 初期表示の設定
   if (window.innerWidth >= 450) {
@@ -32,27 +35,26 @@ document.addEventListener('DOMContentLoaded', function() {
   // 画面サイズが変更された時にプレビューのサイズを切り替える
   window.addEventListener('resize', function() {
     if (window.innerWidth >= 450) {
-        PrevImg.classList.add('upsize');
-        PrevImg.classList.remove('downsize', 'more-downsize');
-        DeleteBtn.classList.add('fa-2x', 'py-1');
-        DeleteBtn.classList.remove('fa-lg', 'py-3', 'py-4');
-        AvatarInputArea.classList.add('avatar-input-upsize');
-        AvatarInputArea.classList.remove('avatar-input-downsize', 'avatar-input-more-downsize');
+      PrevImg.classList.add('upsize');
+      PrevImg.classList.remove('downsize', 'more-downsize');
+      DeleteBtn.classList.add('fa-2x', 'py-1');
+      DeleteBtn.classList.remove('fa-lg', 'py-3', 'py-4');
+      AvatarInputArea.classList.add('avatar-input-upsize');
+      AvatarInputArea.classList.remove('avatar-input-downsize', 'avatar-input-more-downsize');
     } else if (window.innerWidth >= 370) {
-        PrevImg.classList.add('downsize');
-        PrevImg.classList.remove('upsize', 'more-downsize');
-        DeleteBtn.classList.add('fa-lg', 'py-3');
-        DeleteBtn.classList.remove('fa-2x', 'py-1', 'py-4');
-        AvatarInputArea.classList.add('avatar-input-downsize');
-        AvatarInputArea.classList.remove('avatar-input-upsize', 'avatar-input-more-downsize');
+      PrevImg.classList.add('downsize');
+      PrevImg.classList.remove('upsize', 'more-downsize');
+      DeleteBtn.classList.add('fa-lg', 'py-3');
+      DeleteBtn.classList.remove('fa-2x', 'py-1', 'py-4');
+      AvatarInputArea.classList.add('avatar-input-downsize');
+      AvatarInputArea.classList.remove('avatar-input-upsize', 'avatar-input-more-downsize');
     } else if (window.innerWidth <= 369) {
-        PrevImg.classList.add('more-downsize');
-        PrevImg.classList.remove('downsize', 'upsize');
-        AvatarInputArea.classList.add('avatar-input-more-downsize');
-        AvatarInputArea.classList.remove('avatar-input-downsize', 'avatar-input-upsize');
+      PrevImg.classList.add('more-downsize');
+      PrevImg.classList.remove('downsize', 'upsize');
+      AvatarInputArea.classList.add('avatar-input-more-downsize');
+      AvatarInputArea.classList.remove('avatar-input-downsize', 'avatar-input-upsize');
     }
   });
-
 
   $(function() {
     function readURL(input) {
@@ -65,8 +67,43 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     }
     $("#user_avatar").change(function() {
+      // エラーメッセージとスタイルをクリア
+      $('.error-message').remove();
+      $(this).removeClass('error-input');
+
+      // 画像ファイルのバリデーション
+      const file = this.files[0];
+      const fileSize = file.size;
+      if (fileSize > 5 * 1024 * 1024) {
+        // エラーメッセージを表示
+        $(this).after('<div class="error-message text-danger text-center font-mini-size mt-2">画像サイズ上限：5MB以下</div>');
+        // エラースタイルを適用
+        $(this).addClass('error-input');
+        AvatarInput.value = null;
+        return; // 処理を中断
+      }
       readURL(this);
       DeleteBtnArea.classList.add('open');
+    });
+
+    nameField.addEventListener('input', function() {
+      // 入力値を取得
+      var inputValue = this.value.trim();
+      
+      // 入力値が空でない場合
+      if (inputValue.length > 0) {
+        // ボタンの無効化を解除し、requireクラスを削除
+        UpdateBtn.disabled = false;
+        nameField.style.borderColor = '';
+        nameField.style.borderWidth = '';
+        nameLabel.classList.remove('require');
+      } else {
+        // 入力値が空の場合、ボタンを無効化し、requireクラスを追加
+        UpdateBtn.disabled = true;
+        nameField.style.borderColor = 'red';
+        nameField.style.borderWidth = '1.5px';
+        nameLabel.classList.add('require');
+      }
     });
 
     DeleteBtnArea.addEventListener('click', function() {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
             </div>
 
             <!-- サイドバー -->
-            <div class="sidebar-wrapper col-xl-2 col-lg-2 bg-white z-2">
+            <div class="sidebar-wrapper col-xl-2 col-lg-2 bg-white z-3">
               <%= render "/shared/sidebar" %>
             </div>
 
@@ -50,7 +50,7 @@
             <%= render "/shared/rakuten_search_modal" %>
 
             <!-- フッターPC以上 -->
-            <div class="footer-wrapper bg-light z-3 mt-4 d-sm-block d-none">
+            <div class="footer-wrapper bg-light z-2 mt-4 d-sm-block d-none">
               <%= render "/shared/footer" %>
             </div>
 

--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -2,12 +2,12 @@
   <ul class='d-flex crud-menu-btn list-inline m-0'>
     <li class="list-inline-item">
       <%= link_to edit_post_path(post), class: "hover-opacity-50" do %>
-        <i class="fas fa-pencil-alt fa-lg text-dark"></i>
+        <h4 class="m-0"><i class="fas fa-pencil-alt text-dark"></i></h4>
       <% end %>
     </li>
-    <li class="list-inline-item">
+    <li class="list-inline-item ms-1">
       <%= link_to post_path(post), class: "hover-opacity-50", method: :delete, data: {confirm: t('defaults.message.delete_confirm', item: Post.model_name.human)} do %>
-        <i class="fas fa-trash fa-lg text-dark"></i>
+        <h4 class="m-0"><i class="fas fa-trash text-dark"></i></h4>
       <% end %>
     </li>
   </ul>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<div class="col-12 col-sm-6 col-xl-4 mb-3 px-4 px-sm-2">
+<div class="col-12 col-sm-10 col-md-6 col-xl-4 mb-3 px-4 px-sm-2">
   <div class="card shadow-sm">
     <div class="header-area <%= controller_name == 'users' && action_name == 'show' ? 'd-none' : '' %>">
       <div class="container">
@@ -14,8 +14,6 @@
           <div class="operation_area d-flex align-items-center ml-auto">
             <% if current_user.own?(post) %>
               <%= render 'posts/crud_menus', post: post %>
-            <% else %>
-              <%= render 'posts/like_button', post: post %>
             <% end %>
           </div>
         </div>
@@ -46,7 +44,7 @@
                                       style: "height: auto; width: auto;" %>
       <% end %>
 
-      <div class="card-body hover-opacity-50 pt-3">
+      <div class="card-body pt-3">
         <div class="d-flex align-items-center h4 mb-3">
           <%= render 'posts/likes_and_items_count', post: post %>
         </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -44,7 +44,7 @@
                                       style: "height: auto; width: auto;" %>
       <% end %>
 
-      <div class="card-body pt-3">
+      <div class="card-body hover-opacity-50 pt-3">
         <div class="d-flex align-items-center h4 mb-3">
           <%= render 'posts/likes_and_items_count', post: post %>
         </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <!-- 掲示板一覧 -->
-  <div class="row mb-sm-4">
+  <div class="row mb-sm-4 justify-content-center">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>

--- a/app/views/posts/likes.html.erb
+++ b/app/views/posts/likes.html.erb
@@ -23,7 +23,7 @@
   <% end %>
 
   <!-- 掲示板一覧 -->
-  <div class="row mb-sm-4">
+  <div class="row mb-sm-4 justify-content-center">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -93,7 +93,7 @@
         <% if @post.items.present? %>
           <%= render 'item_list' %>
         <% else %>
-          <p class="text-center my-4">アイテムは登録されていません</p>
+          <p class="text-center font-mini-size text-secondary text-decoration-underline fw-bold my-4">アイテムは登録されていません</p>
         <% end %>
       </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -21,14 +21,18 @@
           <%= link_to @post.user.name, user_path(@post.user), class: "fw-bold text-dark hover-opacity-50", style:"text-decoration:none;" %>
         </div>
         <div class="operation_area d-flex align-items-center ml-auto">
-          <div class="like-count d-flex align-items-center fs-4">
-            <i class="fa-solid fa-heart text-danger"></i>
-            <div class="text-dark ms-1">
-              <div class="fs-5" id="likes-count-<%= @post.id %>">
-                <%= @post.likes.count %>
+          <% if current_user.own?(@post) %>
+            <div class="like-count d-flex align-items-center fs-4">
+              <i class="fa-solid fa-heart text-danger"></i>
+              <div class="text-dark ms-1">
+                <div class="fs-5" id="likes-count-<%= @post.id %>">
+                  <%= @post.likes.count %>
+                </div>
               </div>
             </div>
-          </div>
+          <% else %>
+            <%= render 'posts/like_button', post: @post %>
+          <% end %>
         </div>
       </div>
     </div>
@@ -68,8 +72,6 @@
         <div class="ms-auto">
           <% if current_user.own?(@post) %>
             <%= render 'posts/crud_menus', post: @post %>
-          <% else %>
-            <%= render 'posts/like_button', post: @post %>
           <% end %>
         </div>
       </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -32,9 +32,11 @@
             <% end %>
           </div>
           <div class="form-group">
-            <i class="fas fa-user me-1"></i>
-            <%= f.label :name, class: "fw-bold" %>
-            <%= f.text_field :name, class: 'form-control bg-light', placeholder: User.human_attribute_name(:name) %>
+            <div class="d-flex align-items-center">
+              <i class="fas fa-user me-1 mb-2"></i>
+              <%= f.label :name, class: "fw-bold", for: "name_field" %>
+            </div>
+            <%= f.text_field :name, class: 'form-control bg-light', placeholder: User.human_attribute_name(:name), id: 'name_field' %>
           </div>
           <div class="form-group">
             <i class="fas fa-bicycle"></i>
@@ -47,7 +49,7 @@
             <%= f.text_area :bio, class: 'form-control bg-light', placeholder: User.human_attribute_name(:bio), rows: 2 %>
           </div>
           <div class="form-group">
-            <%= f.submit t("defaults.update"), class: 'btn btn-primary btn-block font-weight-bold rounded-pill mt-4' %>
+            <%= f.submit t("defaults.update"), class: 'btn btn-primary btn-block font-weight-bold rounded-pill mt-4', id: 'profile_update_btn' %>
           </div>
         <% end %>
       </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class='footer py-3'>
   <div class='container'>
     <div class='row'>
-      <div class='col-md-12 text-center text-secondary'>
+      <div class='col-md-12 offset-lg-2 col-lg-10 offset-xl-1 col-xl-11 text-center text-secondary'>
         <div class="fw-bold fs-3 mb-2">~ INFORMATION ~</div>
         <%= link_to t("defaults.terms"), '/terms', class: 'text-secondary m-2', style: "text-decoration:none;" %>
         <span><%= " / " %></span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -80,7 +80,7 @@
     <%= render 'posts/sort_posts_menu' %>
   </div>
 
-  <div class="row mb-sm-4">
+  <div class="row mb-sm-4 justify-content-center">
     <% if @posts.present? %>
       <%= render @posts %>
     <% else %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -84,6 +84,7 @@ ja:
       my_bike: 'お気に入り(所有する)自転車メーカー'
       registered: '登録済みの方はこちら'
     create:
+      title: 'ユーザー登録'
       success: 'ユーザー登録が完了しました'
       fail: 'ユーザー登録に失敗しました'
     show:
@@ -122,12 +123,16 @@ ja:
       post_index: 'ログ一覧'
     new:
       title: 'ログ投稿'
+    create:
+      title: 'ログ投稿'
     show:
       title: 'ログ詳細'
       og_title: "%{user}さんの投稿ログ/%{date} - ChariLog"
       edit_images: '写真を追加・編集'
       delete_post: 'ログを削除'
     edit:
+      title: 'ログ編集'
+    update:
       title: 'ログ編集'
     bookmarks:
       title: 'ブックマーク一覧'
@@ -148,6 +153,8 @@ ja:
   profiles:
     edit:
       title: 'プロフィール編集'
+    update:
+      title: 'プロフィール編集'
   password_resets:
     new:
       title: 'パスワード再設定申請'
@@ -158,5 +165,6 @@ ja:
       new_password: '新しいパスワード'
       new_password_confirm: '新しいパスワード確認'
     update:
+      title: 'メール・パスワード再設定'
       success: '再設定が完了しました'
       fail: '再設定に失敗しました'

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -17,7 +17,7 @@ ja:
     resetting: '再設定'
     register: '登録する'
     post: '投稿する'
-    edit: '編集する'
+    edit: '更新する'
     delete: '削除する'
     submit: '送信する'
     update: '更新する'


### PR DESCRIPTION
## 概要

* プロフィール編集時のバリデーションエラーメッセージの出力をjsにてコントロールするように実装
* サイドバーとフッターの表示優先度をサイドバーが上に来るように変更
* いいねボタン/CRUDメニューアイコンのレイアウト調整
* 投稿一覧やいいね一覧等の各投稿の余白(両幅)を調整
* 各投稿のcard-bodyホバー時のエフェクトを追加
* 投稿詳細ページ内のアイテム未登録時のテキストのレイアウトを調整
* 投稿編集ページのupdateボタンのテキストを「編集する」から「更新する」に変更
* バリデーションエラー時に各ページのタイトルがTitleとなってしまう問題を解消

## 以下のissueの内容を含むpull requestです

#97