### PR TITLE
Add: 検索条件リセット/検索オートコンプリート機能実装

### DIFF
--- a/app/assets/javascripts/search_clear_function.js
+++ b/app/assets/javascripts/search_clear_function.js
@@ -1,0 +1,15 @@
+$(function () {
+  $("#search_clear_btn").on("click", function () {
+      clearForm(this.form);
+  });
+
+  function clearForm (form) {
+    $(form)
+      .find("input, select, textarea")
+      .not(":button, :submit, :reset, :hidden")
+      .val("")
+      .prop("selected", false)
+    ;
+    $('select[name=sort_order]').children().first().attr('selected', true);
+  }
+});

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -46,3 +46,7 @@
   object-position: center center;
   border-radius: 50%;
 }
+
+.list-group-item:hover {
+  background-color: rgb(174, 222, 231);
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,13 @@ class UsersController < ApplicationController
     load_users
   end
 
+  def search
+    @users = User.where("name like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def load_users

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,7 +1,9 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from "stimulus-autocomplete"
 import ImagesController from "./images_controller"
 
 const application = Application.start()
+application.register('autocomplete', Autocomplete)
 application.register("images", ImagesController)
 
 // Configure Stimulus development experience

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,13 +1,20 @@
+<%= javascript_include_tag "search_clear_function.js" %>
+
 <%= search_form_for @q, url: url do |f| %>
   <div class="input-group justify-content-sm-center mb-3">
-    <div class="col-10 col-sm-5 ps-0">
+    <div class="col-8 col-sm-5 ps-0">
       <%= f.search_field :title_or_content_cont, class: 'form-control', placeholder: t("defaults.input_keyword") %>
     </div>
-    <div class="col-10 col-sm-5 ps-0">
+    <div class="col-8 col-sm-4 col-md-5 ps-0">
       <%= f.select :user_my_bike_eq, User.my_bikes_i18n.invert.map{|key, value| [key, User.my_bikes[value]]}, { include_blank: t("defaults.select_bike") }, { class: 'form-select text-secondary pointer' } %>
     </div>
-    <div class="col-1 ps-0">
-      <%= f.submit class: 'btn btn-outline-success fw-bold px-2' %>
+    <div class="col-2 col-md-1 ps-0 text-center">
+      <%= f.submit class: 'btn btn-outline-success fw-bold px-2 px-xl-3' %>
+    </div>
+    <div class="col-1 ps-0 text-center">
+      <button type="button" class="btn btn-light border fw-bold p-2 px-xl-3" id="search_clear_btn" style="font-size: smaller;">
+        クリア
+      </button>
     </div>
   </div>
 <% end %>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,13 +1,20 @@
+<%= javascript_include_tag "search_clear_function.js" %>
+
 <%= search_form_for @q, url: url do |f| %>
   <div class="input-group justify-content-sm-center mb-3">
-    <div class="col-10 col-sm-5 ps-0">
+    <div class="col-8 col-sm-5 ps-0">
       <%= f.search_field :name_cont, class: 'form-control', placeholder: t("defaults.input_user_name") %>
     </div>
-    <div class="col-10 col-sm-5 ps-0">
+    <div class="col-8 col-sm-4 col-md-5 ps-0">
       <%= f.select :my_bike_eq, User.my_bikes_i18n.invert.map{|key, value| [key, User.my_bikes[value]]}, { include_blank: t("defaults.select_bike") }, { class: 'form-select text-secondary pointer' } %>
     </div>
-    <div class="col-1 ps-0">
-      <%= f.submit class: 'btn btn-outline-success fw-bold px-2' %>
+    <div class="col-2 col-md-1 ps-0 text-center">
+      <%= f.submit class: 'btn btn-outline-success fw-bold px-2 px-xl-3' %>
+    </div>
+    <div class="col-1 ps-0 text-center">
+      <button type="button" class="btn btn-light border fw-bold p-2 px-xl-3" id="search_clear_btn" style="font-size: smaller;">
+        クリア
+      </button>
     </div>
   </div>
 <% end %>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -3,7 +3,11 @@
 <%= search_form_for @q, url: url do |f| %>
   <div class="input-group justify-content-sm-center mb-3">
     <div class="col-8 col-sm-5 ps-0">
-      <%= f.search_field :name_cont, class: 'form-control', placeholder: t("defaults.input_user_name") %>
+      <div data-controller="autocomplete" data-autocomplete-url-value="/users/search" role="combobox">
+        <%= f.search_field :name_cont, data: { autocomplete_target: 'input' }, class: 'form-control', placeholder: t("defaults.input_user_name") %>
+        <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+        <ul class="list-group position-absolute w-100" data-autocomplete-target="results"></ul>
+      </div>
     </div>
     <div class="col-8 col-sm-4 col-md-5 ps-0">
       <%= f.select :my_bike_eq, User.my_bikes_i18n.invert.map{|key, value| [key, User.my_bikes[value]]}, { include_blank: t("defaults.select_bike") }, { class: 'form-select text-secondary pointer' } %>

--- a/app/views/users/search.html.erb
+++ b/app/views/users/search.html.erb
@@ -1,0 +1,5 @@
+<% @users.each do |user| %>
+  <li class="list-group-item py-2 px-3 rounded-md" role="option" data-autocomplete-value="<%= user.id %>" data-autocomplete-label="<%= user.name %>">
+    <%= user.name %>
+  </li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :new, :create, :show] do
     resource :relationships, only: [:create, :destroy]
     member { get 'follows', 'followers' }
+    collection { get 'search' }
   end
 
   resource :profile, only: [:edit, :update] do

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
     "node-sass": "^9.0.0",
+    "stimulus-autocomplete": "^3.1.0",
     "swiper": "^11.0.5",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7247,6 +7247,11 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
## 概要

* 検索条件(インプット・セレクト)をリセットするための「クリア」ボタンを追加
* ユーザー検索を行う際、ユーザー名入力時に検索候補が表示されるように実装(stimulusを使用したオートコンプリート機能の追加)

## 以下のissueに関するpull requestです

#98

## 今後予定している対応

投稿のタグ機能を実装でき次第、投稿検索におけるオートコンプリート機能(タグを対象とする)を追加実装したいと考えています。