### PR TITLE
Fix: postとrouteの関連付け修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,7 +13,7 @@ class Post < ApplicationRecord
 
   has_many :comments, dependent: :destroy
 
-  has_one :route
+  has_one :route, dependent: :destroy
 
   validates :title, presence: true
 end


### PR DESCRIPTION
## 概要

* postとrouteの関連付けに、dependent(destroy)オプションを付与し忘れていたため該当箇所を修正