### PR TITLE
Update: 移動ルート保存機能アップデート(経由地の追加)

### DIFF
--- a/app/controllers/concerns/set_route.rb
+++ b/app/controllers/concerns/set_route.rb
@@ -6,6 +6,10 @@ module SetRoute
         start_longitude: params[:post][:start_longitude],
         waypoint_latitude: params[:post][:waypoint_latitude],
         waypoint_longitude: params[:post][:waypoint_longitude],
+        waypoint1_latitude: params[:post][:waypoint1_latitude],
+        waypoint1_longitude: params[:post][:waypoint1_longitude],
+        waypoint2_latitude: params[:post][:waypoint2_latitude],
+        waypoint2_longitude: params[:post][:waypoint2_longitude],
         end_latitude: params[:post][:end_latitude],
         end_longitude: params[:post][:end_longitude],
         post_id: @post.id

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -66,14 +66,15 @@
         <div class="form-group">
           <div class="d-flex align-items-center flex-wrap mb-2">
             <i class="fa-solid fa-location-dot me-1"></i>
-            <div class="fw-bold">ルート登録</div>
-            <span class="font-mini-size">（A:出発地 / B:経由地 / C:目的地）</span>
+            <div class="fw-bold me-1">ルート登録</div>
+            <span class="font-mini-size">(経由地1箇所の場合 → A:出発地,B:経由地,C:目的地)</span>
           </div>
 
           <% if f.object.new_record? %>
             <div class="route-add-detail text-danger font-mini-size fw-bold">
-              ・[タップ]or[クリック]で<span class="text-decoration-underline">A → B → C</span>の順に設定<br>
-              ・３地点設定後に<span class="text-decoration-underline">【ルート表示】</span>押下で登録可能<br>
+              ・[タップ],[クリック]で<span class="text-decoration-underline">A〜E</span>の順に設定<br>
+              ・<span class="text-decoration-underline">最大5地点(経由地3箇所を含む)</span>まで設定可能<br>
+              ・ルート表示/登録は<span class="text-decoration-underline">最低3地点(A,B,C)</span>が必要<br>
               ・投稿後の編集/削除不可
             </div>
             <!-- 地図表示エリア -->

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -84,6 +84,10 @@
             <%= f.hidden_field :start_longitude, id: "start_longitude" %>
             <%= f.hidden_field :waypoint_latitude, id: "waypoint_latitude" %>
             <%= f.hidden_field :waypoint_longitude, id: "waypoint_longitude" %>
+            <%= f.hidden_field :waypoint1_latitude, id: "waypoint1_latitude" %>
+            <%= f.hidden_field :waypoint1_longitude, id: "waypoint1_longitude" %>
+            <%= f.hidden_field :waypoint2_latitude, id: "waypoint2_latitude" %>
+            <%= f.hidden_field :waypoint2_longitude, id: "waypoint2_longitude" %>
             <%= f.hidden_field :end_latitude, id: "end_latitude" %>
             <%= f.hidden_field :end_longitude, id: "end_longitude" %>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -67,7 +67,17 @@
           <div class="d-flex align-items-center flex-wrap mb-2">
             <i class="fa-solid fa-location-dot me-1"></i>
             <div class="fw-bold me-1">ルート登録</div>
-            <span class="font-mini-size">(経由地1箇所の場合 → A:出発地,B:経由地,C:目的地)</span>
+            <% if f.object.new_record? %>
+              <span class="font-mini-size">(経由地1箇所→ A:出発地 / B:経由地 / C:目的地)</span>
+            <% else %>
+              <% if @route.waypoint_latitude.present? && @route.waypoint1_latitude.nil? %>
+                <span class="font-mini-size">（A:出発地 / B:経由地 / C:目的地）</span>
+              <% elsif @route.waypoint1_latitude.present? && @route.waypoint2_latitude.nil? %>
+                <span class="font-mini-size">（A:出発地 / B,C:経由地 / D:目的地）</span>
+              <% else %>
+                <span class="font-mini-size">（A:出発地 / B,C,D:経由地 / E:目的地）</span>
+              <% end %>
+            <% end %>
           </div>
 
           <% if f.object.new_record? %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -35,12 +35,27 @@
 
     function displayRoute() {
       var start = {lat: <%= @route.start_latitude %>, lng: <%= @route.start_longitude %>};
-      var waypoint = {lat: <%= @route.waypoint_latitude %>, lng: <%= @route.waypoint_longitude %>};
       var end = {lat: <%= @route.end_latitude %>, lng: <%= @route.end_longitude %>};
+      var waypoints = [];
+
+      <% if @route.waypoint_latitude.present? %>
+        var waypoint = {lat: <%= @route.waypoint_latitude %>, lng: <%= @route.waypoint_longitude %>}
+        waypoints.push({ location: waypoint, stopover: true });
+      <% end %>
+
+      <% if @route.waypoint1_latitude.present? %>
+        var waypoint1 = {lat: <%= @route.waypoint1_latitude %>, lng: <%= @route.waypoint1_longitude %>}
+        waypoints.push({ location: waypoint1, stopover: true });
+      <% end %>
+
+      <% if @route.waypoint2_latitude.present? %>
+        var waypoint2 = {lat: <%= @route.waypoint2_latitude %>, lng: <%= @route.waypoint2_longitude %>}
+        waypoints.push({ location: waypoint2, stopover: true });
+      <% end %>
 
       var request = {
         origin: start,
-        waypoints: [{ location: waypoint, stopover: true }],
+        waypoints: waypoints,
         destination: end,
         travelMode: 'BICYCLING'
       };

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -37,8 +37,8 @@
   }
 
   function placeMarker(location) {
-    if (markers.length >= 3) {
-      alert("You've already placed 3 markers.");
+    if (markers.length >= 5) {
+      alert("ルート形成に使用可能なピンは最大5つです");
       return;
     }
 
@@ -55,12 +55,31 @@
     var index = markers.length - 1;
     document.getElementById('start_latitude').value = markers[0] ? markers[0].getPosition().lat() : '';
     document.getElementById('start_longitude').value = markers[0] ? markers[0].getPosition().lng() : '';
-    document.getElementById('waypoint_latitude').value = markers[1] ? markers[1].getPosition().lat() : '';
-    document.getElementById('waypoint_longitude').value = markers[1] ? markers[1].getPosition().lng() : '';
-    document.getElementById('end_latitude').value = markers[2] ? markers[2].getPosition().lat() : '';
-    document.getElementById('end_longitude').value = markers[2] ? markers[2].getPosition().lng() : '';
 
     if (markers.length === 3) {
+      document.getElementById('waypoint_latitude').value = markers[1] ? markers[1].getPosition().lat() : '';
+      document.getElementById('waypoint_longitude').value = markers[1] ? markers[1].getPosition().lng() : '';
+      document.getElementById('end_latitude').value = markers[2] ? markers[2].getPosition().lat() : '';
+      document.getElementById('end_longitude').value = markers[2] ? markers[2].getPosition().lng() : '';
+    } else if (markers.length === 4) {
+      document.getElementById('waypoint_latitude').value = markers[1] ? markers[1].getPosition().lat() : '';
+      document.getElementById('waypoint_longitude').value = markers[1] ? markers[1].getPosition().lng() : '';
+      document.getElementById('waypoint1_latitude').value = markers[2] ? markers[2].getPosition().lat() : '';
+      document.getElementById('waypoint1_longitude').value = markers[2] ? markers[2].getPosition().lng() : '';
+      document.getElementById('end_latitude').value = markers[3] ? markers[3].getPosition().lat() : '';
+      document.getElementById('end_longitude').value = markers[3] ? markers[3].getPosition().lng() : '';
+    } else if (markers.length === 5) {
+      document.getElementById('waypoint_latitude').value = markers[1] ? markers[1].getPosition().lat() : '';
+      document.getElementById('waypoint_longitude').value = markers[1] ? markers[1].getPosition().lng() : '';
+      document.getElementById('waypoint1_latitude').value = markers[2] ? markers[2].getPosition().lat() : '';
+      document.getElementById('waypoint1_longitude').value = markers[2] ? markers[2].getPosition().lng() : '';
+      document.getElementById('waypoint2_latitude').value = markers[3] ? markers[3].getPosition().lat() : '';
+      document.getElementById('waypoint2_longitude').value = markers[3] ? markers[3].getPosition().lng() : '';
+      document.getElementById('end_latitude').value = markers[4] ? markers[4].getPosition().lat() : '';
+      document.getElementById('end_longitude').value = markers[4] ? markers[4].getPosition().lng() : '';
+    }
+
+    if (markers.length >= 3) {
       DisplayRouteBtn.disabled = false;
     }
   }
@@ -74,6 +93,10 @@
     document.getElementById('start_longitude').value = '';
     document.getElementById('waypoint_latitude').value = '';
     document.getElementById('waypoint_longitude').value = '';
+    document.getElementById('waypoint1_latitude').value = '';
+    document.getElementById('waypoint1_longitude').value = '';
+    document.getElementById('waypoint2_latitude').value = '';
+    document.getElementById('waypoint2_longitude').value = '';
     document.getElementById('end_latitude').value = '';
     document.getElementById('end_longitude').value = '';
 
@@ -84,12 +107,22 @@
 
   function displayRoute() {
     var start = markers[0].getPosition();
-    var waypoint = markers[1].getPosition();
-    var end = markers[2].getPosition();
+    var end = markers[markers.length - 1].getPosition();
+    var waypoints = [];
+
+    // ウェイポイントが存在する場合、配列に追加
+    if (markers.length > 2) {
+      for (var i = 1; i < markers.length - 1; i++) {
+        waypoints.push({
+          location: markers[i].getPosition(),
+          stopover: true
+        });
+      }
+    }
 
     var request = {
       origin: start,
-      waypoints: [{ location: waypoint, stopover: true }],
+      waypoints: waypoints,
       destination: end,
       travelMode: 'BICYCLING'
     };

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -95,7 +95,13 @@
           <div class="d-flex align-items-center flex-wrap mb-2">
             <i class="fa-solid fa-location-dot me-1"></i>
             <div class="fw-bold">移動ルート</div>
-            <span class="font-mini-size">（A:出発地 / B:経由地 / C:目的地）</span>
+            <% if @route.waypoint_latitude.present? && @route.waypoint1_latitude.nil? %>
+              <span class="font-mini-size">（A:出発地 / B:経由地 / C:目的地）</span>
+            <% elsif @route.waypoint1_latitude.present? && @route.waypoint2_latitude.nil? %>
+              <span class="font-mini-size">（A:出発地 / B,C:経由地 / D:目的地）</span>
+            <% else %>
+              <span class="font-mini-size">（A:出発地 / B,C,D:経由地 / E:目的地）</span>
+            <% end %>
           </div>
           <!-- 地図表示エリア -->
           <div id="map" style="height: 300px;"></div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -181,12 +181,27 @@
 
     function displayRoute() {
       var start = {lat: <%= @route.start_latitude %>, lng: <%= @route.start_longitude %>};
-      var waypoint = {lat: <%= @route.waypoint_latitude %>, lng: <%= @route.waypoint_longitude %>};
       var end = {lat: <%= @route.end_latitude %>, lng: <%= @route.end_longitude %>};
+      var waypoints = [];
+
+      <% if @route.waypoint_latitude.present? %>
+        var waypoint = {lat: <%= @route.waypoint_latitude %>, lng: <%= @route.waypoint_longitude %>}
+        waypoints.push({ location: waypoint, stopover: true });
+      <% end %>
+
+      <% if @route.waypoint1_latitude.present? %>
+        var waypoint1 = {lat: <%= @route.waypoint1_latitude %>, lng: <%= @route.waypoint1_longitude %>}
+        waypoints.push({ location: waypoint1, stopover: true });
+      <% end %>
+
+      <% if @route.waypoint2_latitude.present? %>
+        var waypoint2 = {lat: <%= @route.waypoint2_latitude %>, lng: <%= @route.waypoint2_longitude %>}
+        waypoints.push({ location: waypoint2, stopover: true });
+      <% end %>
 
       var request = {
         origin: start,
-        waypoints: [{ location: waypoint, stopover: true }],
+        waypoints: waypoints,
         destination: end,
         travelMode: 'BICYCLING'
       };

--- a/db/migrate/20240424062823_add_waypoints_to_routes.rb
+++ b/db/migrate/20240424062823_add_waypoints_to_routes.rb
@@ -1,0 +1,8 @@
+class AddWaypointsToRoutes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :routes, :waypoint1_latitude, :float, null: true
+    add_column :routes, :waypoint1_longitude, :float, null: true
+    add_column :routes, :waypoint2_latitude, :float, null: true
+    add_column :routes, :waypoint2_longitude, :float, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_10_080227) do
+ActiveRecord::Schema.define(version: 2024_04_24_062823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,10 @@ ActiveRecord::Schema.define(version: 2024_04_10_080227) do
     t.float "end_longitude"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.float "waypoint1_latitude"
+    t.float "waypoint1_longitude"
+    t.float "waypoint2_latitude"
+    t.float "waypoint2_longitude"
     t.index ["post_id"], name: "index_routes_on_post_id"
   end
 


### PR DESCRIPTION
## 概要

* 経由地を新たに2箇所設定できるように実装


## 確認方法

1. ログイン後、投稿作成ページに遷移してください。
2. タイトル入力後、3~5地点お好きな場所を選んでピンをつけて、「ルート表示」ボタンを押下してください。
3. ルートが表示されるので、投稿ボタンから投稿を完了してください。
4. 詳細ページや編集ページにて、ルートが正常に反映されていることを確認してください。