### PR TITLE
Fix: 移動ルート保存機能エラー修正

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -70,9 +70,9 @@
             <% if f.object.new_record? %>
               <span class="font-mini-size">(経由地1箇所→ A:出発地 / B:経由地 / C:目的地)</span>
             <% else %>
-              <% if @route.waypoint_latitude.present? && @route.waypoint1_latitude.nil? %>
+              <% if @route&.waypoint_latitude.present? && @route&.waypoint1_latitude.nil? %>
                 <span class="font-mini-size">（A:出発地 / B:経由地 / C:目的地）</span>
-              <% elsif @route.waypoint1_latitude.present? && @route.waypoint2_latitude.nil? %>
+              <% elsif @route&.waypoint1_latitude&.present? && @route&.waypoint2_latitude&.nil? %>
                 <span class="font-mini-size">（A:出発地 / B,C:経由地 / D:目的地）</span>
               <% else %>
                 <span class="font-mini-size">（A:出発地 / B,C,D:経由地 / E:目的地）</span>


### PR DESCRIPTION
## 概要

* 移動ルートを登録せずに投稿した場合、編集ページにアクセスできない問題があったためコードを修正
* nilを許可するためのぼっち演算子を追加し忘れていたことが原因

